### PR TITLE
Update Winget Releaser workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,13 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "13:00"
-  open-pull-requests-limit: 99
-  versioning-strategy: increase
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "13:00"
+    open-pull-requests-limit: 99
+    versioning-strategy: increase

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -7,7 +7,7 @@ jobs:
   publish:
     runs-on: windows-latest # Action can only be run on windows
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@latest
+      - uses: vedantmgoyal2009/winget-releaser@v1
         with:
           identifier: ArmCord.ArmCord
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Winget Releaser is now switching to version tags instead of the `latest` tag.

As mentioned in https://github.com/ArmCord/ArmCord/pull/202#issuecomment-1260245839, please install the [Pull](https://github.com/apps/pull) app on the winget-pkgs fork to ensure that it is always updated.