### PR TITLE
Keybind fixes (Zoom & DevTools consistent with chrome/discord desktop)

### DIFF
--- a/src/menu.ts
+++ b/src/menu.ts
@@ -49,7 +49,7 @@ export async function setMenu() {
                     label: "Developer tools",
                     accelerator: "CmdOrCtrl+Shift+I",
                     click: function () {
-                        mainWindow.webContents.openDevTools();
+                        mainWindow.webContents.toggleDevTools();
                     }
                 },
                 {
@@ -97,6 +97,9 @@ export async function setMenu() {
             label: "Zoom",
             submenu: [
                 {label: "Zoom in", accelerator: "CmdOrCtrl+Plus", role: "zoomIn"},
+                // Fix for zoom in on keyboards with dedicated + like QWERTZ (or numpad)
+                // See https://github.com/electron/electron/issues/14742 and https://github.com/electron/electron/issues/5256
+                {label: "Zoom in", accelerator: "CmdOrCtrl+=", role: "zoomIn", visible: false},
                 {label: "Zoom out", accelerator: "CmdOrCtrl+-", role: "zoomOut"}
             ]
         }


### PR DESCRIPTION
Makes DevTools keybind toggle devtools instead of open which makes them consistent with chrome and regular Discord Desktop

Also fixes the zoom in shortcut for keyboards with dedicated + key

Closes #253 