### PR TITLE
Add portable mode

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 // Modules to control application life and create native browser window
 import {app, BrowserWindow, session} from "electron";
 import "v8-compile-cache";
-import {getConfig, checkIfConfigExists, injectElectronFlags, installModLoader} from "./utils";
+import {checkForDataFolder, getConfig, checkIfConfigExists, injectElectronFlags, installModLoader} from "./utils";
 import "./extensions/mods";
 import "./tray";
 import {createCustomWindow, createNativeWindow, createTransparentWindow, mainWindow} from "./window";
@@ -22,6 +22,7 @@ if (process.platform == "linux") {
         }
     }
 }
+checkForDataFolder();
 checkIfConfigExists();
 injectElectronFlags();
 app.whenReady().then(async () => {

--- a/src/settings/main.ts
+++ b/src/settings/main.ts
@@ -1,5 +1,6 @@
 import {BrowserWindow, shell, ipcMain, app, clipboard} from "electron";
 import {
+    checkForDataFolder,
     getConfig,
     setConfigBulk,
     Settings,
@@ -16,6 +17,7 @@ import fs from "fs";
 import {mainWindow} from "../window";
 var settingsWindow: BrowserWindow;
 var instance: number = 0;
+checkForDataFolder();
 const userDataPath = app.getPath("userData");
 const storagePath = path.join(userDataPath, "/storage/");
 const themesPath = path.join(userDataPath, "/themes/");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -222,6 +222,14 @@ export async function getWindowState(object: string) {
 }
 //ArmCord Settings/Storage manager
 
+export function checkForDataFolder() {
+    const dataPath = path.join(path.dirname(app.getPath("exe")), "armcord-data");
+    if (fs.existsSync(dataPath) && fs.statSync(dataPath).isDirectory()) {
+        console.log("Found armcord-data folder. Running in portable mode.");
+        app.setPath("userData", dataPath);
+    }
+}
+
 export interface Settings {
     windowStyle: string;
     channel: string;


### PR DESCRIPTION
This makes ArmCord look for a `data` folder alongside the executable and uses it instead of the default `userData` path. Fixes #52 but definitely needs more testing.
You might have to consider adding documentation and windows zips to release.