### PR TITLE
Fix skipSplash, Add window size/position persistence, Fix white startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "copyfiles": "^2.4.1",
         "electron": "^21.3.0",
         "electron-builder": "^23.6.0",
+        "husky": "^3.1.0",
         "prettier": "^2.7.1",
         "typescript": "^4.9.3"
     },
@@ -39,6 +40,7 @@
         "arrpc": "file:src/arrpc",
         "cross-fetch": "^3.1.5",
         "electron-context-menu": "github:ArmCord/electron-context-menu",
+        "electron-window-state": "^5.0.3",
         "extract-zip": "^2.0.1",
         "v8-compile-cache": "^2.3.0",
         "ws": "^8.11.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
         "copyfiles": "^2.4.1",
         "electron": "^21.3.0",
         "electron-builder": "^23.6.0",
-        "husky": "^3.1.0",
         "prettier": "^2.7.1",
         "typescript": "^4.9.3"
     },
@@ -40,10 +39,10 @@
         "arrpc": "file:src/arrpc",
         "cross-fetch": "^3.1.5",
         "electron-context-menu": "github:ArmCord/electron-context-menu",
-        "electron-window-state": "^5.0.3",
         "extract-zip": "^2.0.1",
         "v8-compile-cache": "^2.3.0",
-        "ws": "^8.11.0"
+        "ws": "^8.11.0",
+        "electron-window-state": "^5.0.3"
     },
     "build": {
         "nsis": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
         "electron-context-menu": "github:ArmCord/electron-context-menu",
         "extract-zip": "^2.0.1",
         "v8-compile-cache": "^2.3.0",
-        "ws": "^8.11.0"
+        "ws": "^8.11.0",
+        "electron-window-state": "^5.0.3"
     },
     "build": {
         "nsis": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ specifiers:
   electron: ^21.3.0
   electron-builder: ^23.6.0
   electron-context-menu: github:ArmCord/electron-context-menu
+  electron-window-state: ^5.0.3
   extract-zip: ^2.0.1
   prettier: ^2.7.1
   typescript: ^4.9.3
@@ -22,6 +23,7 @@ dependencies:
   arrpc: file:src/arrpc
   cross-fetch: 3.1.5
   electron-context-menu: github.com/ArmCord/electron-context-menu/280c81398c02a063f46e3285a9708d8db1a7ce32
+  electron-window-state: 5.0.3
   extract-zip: 2.0.1
   v8-compile-cache: 2.3.0
   ws: 8.11.0
@@ -883,6 +885,14 @@ packages:
       - supports-color
     dev: true
 
+  /electron-window-state/5.0.3:
+    resolution: {integrity: sha512-1mNTwCfkolXl3kMf50yW3vE2lZj0y92P/HYWFBrb+v2S/pCka5mdwN3cagKm458A7NjndSwijynXgcLWRodsVg==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      jsonfile: 4.0.0
+      mkdirp: 0.5.6
+    dev: false
+
   /electron/21.3.0:
     resolution: {integrity: sha512-MGRpshN8fBcx4IRuBABIsGDv0tB/MclIFsyFHFFXsBCUc+vIXaE/E6vuWaniGIFSz5WyeuapfTH5IeRb+7yIfw==}
     engines: {node: '>= 10.17.0'}
@@ -1504,7 +1514,6 @@ packages:
 
   /minimist/1.2.7:
     resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
-    dev: true
 
   /minipass/3.3.4:
     resolution: {integrity: sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==}
@@ -1520,6 +1529,13 @@ packages:
       minipass: 3.3.4
       yallist: 4.0.0
     dev: true
+
+  /mkdirp/0.5.6:
+    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
+    dependencies:
+      minimist: 1.2.7
+    dev: false
 
   /mkdirp/1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
@@ -2234,7 +2250,7 @@ packages:
   file:src/arrpc:
     resolution: {directory: src/arrpc, type: directory}
     name: arrpc
-    version: 1.1.0
+    version: 2.2.0
     dependencies:
       ws: 8.11.0
     transitivePeerDependencies:

--- a/src/content/skipsplash.html
+++ b/src/content/skipsplash.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+    <script>
+        switch (window.armcord.channel) {
+            case "stable":
+                window.location.replace("https://discord.com/app");
+                break;
+            case "canary":
+                window.location.replace("https://canary.discord.com/app");
+                break;
+            case "ptb":
+                window.location.replace("https://ptb.discord.com/app");
+                break;
+            case "hummus":
+                window.location.replace("https://hummus.sys42.net/");
+                break;
+            case undefined:
+                window.location.replace("https://discord.com/app");
+                break;
+            default:
+                window.location.replace("https://discord.com/app");
+        }
+    </script>
+</html>

--- a/src/window.ts
+++ b/src/window.ts
@@ -24,6 +24,8 @@ import {iconPath} from "./main";
 export let mainWindow: BrowserWindow;
 export let inviteWindow: BrowserWindow;
 
+const windowStateKeeper = require('electron-window-state');
+
 var osType = os.type();
 contextMenu({
     showSaveImageAs: true,
@@ -49,6 +51,18 @@ contextMenu({
     ]
 });
 async function doAfterDefiningTheWindow() {
+    let mainWindowState = windowStateKeeper({
+        x: undefined,
+        y: undefined,
+        defaultWidth: 300,
+        defaultHeight: 350
+    })
+    if(await getConfig("skipSplash")) {
+        mainWindow.setPosition(mainWindowState.x,mainWindowState.y)
+        mainWindow.setSize(mainWindowState.width,mainWindowState.height)
+        mainWindowState.manage(mainWindow)
+    }
+
     if (transparency && process.platform === "win32") {
         import("@pyke/vibe").then((vibe) => {
             vibe.applyEffect(mainWindow, "acrylic");
@@ -214,27 +228,14 @@ async function doAfterDefiningTheWindow() {
         await mainWindow.loadFile(path.join(__dirname, "/content/setup.html"));
     } else {
         if ((await getConfig("skipSplash")) == true) {
-            switch (await getConfig("channel")) {
-                case "stable":
-                    await mainWindow.loadURL("https://discord.com/app");
-                    break;
-                case "canary":
-                    await mainWindow.loadURL("https://canary.discord.com/app");
-                    break;
-                case "ptb":
-                    await mainWindow.loadURL("https://ptb.discord.com/app");
-                    break;
-                case "hummus":
-                    await mainWindow.loadURL("https://hummus.sys42.net/");
-                    break;
-                case undefined:
-                    await mainWindow.loadURL("https://discord.com/app");
-                    break;
-                default:
-                    await mainWindow.loadURL("https://discord.com/app");
-            }
+            await mainWindow.loadFile(path.join(__dirname, "/content/skipsplash.html"));
         } else {
             await mainWindow.loadFile(path.join(__dirname, "/content/splash.html"));
+            setTimeout(() => {
+                mainWindow.setPosition(mainWindowState.x,mainWindowState.y,true)
+                mainWindow.setSize(mainWindowState.width,mainWindowState.height,true)
+                mainWindowState.manage(mainWindow)
+            }, 3000);
         }
     }
 }
@@ -246,6 +247,7 @@ export function createCustomWindow() {
         darkTheme: true,
         icon: iconPath,
         frame: false,
+        backgroundColor: "#202225",
         autoHideMenuBar: true,
         webPreferences: {
             sandbox: false,
@@ -263,6 +265,7 @@ export function createNativeWindow() {
         darkTheme: true,
         icon: iconPath,
         frame: true,
+        backgroundColor: "#202225",
         autoHideMenuBar: true,
         webPreferences: {
             sandbox: false,


### PR DESCRIPTION
Man these file comparisons looked much more elegant in github desktop, too bad my github desktop is broken and won't push.

Anyway, this:
  - Fixes the skip splash screen option (do I know why this method works and the old one doesn't? of course not)
  - Adds saving window size/position on close
  - Requires new dependency: electron-window-state
  - Fixes flashing white on startup

I'm probably doing something wrong. No idea how the pnpm stuff works but changing package.json and rerunning `pnpm install` to update pnpm-lock.yaml seems to work fine. 