### PR TITLE
Fix url logic

### DIFF
--- a/src/window.ts
+++ b/src/window.ts
@@ -94,7 +94,7 @@ async function doAfterDefiningTheWindow() {
         if (url === "about:blank") return {action: "allow"};
         // Allow Discord stream popout
         if (url === "https://discord.com/popout") return {action: "allow"};
-        if (url.startsWith("https:" || url.startsWith("http:") || url.startsWith("mailto:"))) {
+        if (url.startsWith("https:") || url.startsWith("http:") || url.startsWith("mailto:")) {
             shell.openExternal(url);
         } else {
             if (ignoreProtocolWarning) {


### PR DESCRIPTION
A misplaced parenthesis meant that the logic didn't work, it would still let https urls work, however it would show the warning on http urls.

(I tested and it worked, though its a pretty simple change)