### PR TITLE
Fix environment access for Linux Wayland patches

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -28,10 +28,10 @@ if (!app.requestSingleInstanceLock()) {
     crashReporter.start({uploadToServer: false, extra: {settingsFile}});
 
     if (process.platform == "linux") {
-        if (process.env.$XDG_SESSION_TYPE == "wayland") {
+        if (process.env.XDG_SESSION_TYPE == "wayland") {
             console.log("Wayland specific patches applied.");
             app.commandLine.appendSwitch("ozone-platform=wayland");
-            if (process.env.$XDG_CURRENT_DESKTOP == "GNOME") {
+            if (process.env.XDG_CURRENT_DESKTOP == "GNOME") {
                 app.commandLine.appendSwitch("enable-features=UseOzonePlatform,WaylandWindowDecorations");
             } else {
                 app.commandLine.appendSwitch("enable-features=UseOzonePlatform");


### PR DESCRIPTION
Corrects a minor slip with environment access. None of the other `process.env` access points in the app do this, so this was the only error.