### PR TITLE
Cut out any Wayland checks in main.ts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -27,18 +27,6 @@ if (!app.requestSingleInstanceLock()) {
     let settingsFile = fs.readFileSync(getConfigLocation(), "utf-8");
     crashReporter.start({uploadToServer: false, extra: {settingsFile}});
 
-    if (process.platform == "linux") {
-        if (process.env.XDG_SESSION_TYPE == "wayland") {
-            console.log("Wayland specific patches applied.");
-            app.commandLine.appendSwitch("ozone-platform=wayland");
-            if (process.env.XDG_CURRENT_DESKTOP == "GNOME") {
-                app.commandLine.appendSwitch("enable-features=UseOzonePlatform,WaylandWindowDecorations");
-            } else {
-                app.commandLine.appendSwitch("enable-features=UseOzonePlatform");
-            }
-        }
-    }
-
     checkForDataFolder();
     checkIfConfigExists();
     injectElectronFlags();


### PR DESCRIPTION
Wayland with Electron is still broken, we shouldn't be forcing it. Additionally, if anything, it should check for Wayland to enable PipeWire, but I'll make a MR for that when the window capturing with PipeWire is improved in ArmCord.