### PR TITLE
Bump Winget Releaser to v2

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -7,7 +7,7 @@ jobs:
   publish:
     runs-on: windows-latest # Action can only be run on windows
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@v1
+      - uses: vedantmgoyal2009/winget-releaser@v2
         with:
           identifier: ArmCord.ArmCord
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Fix recent Winget Releaser error (https://github.com/ArmCord/ArmCord/actions/runs/4272007921). Not sure why dependabot did not bump this.