### PR TITLE
Bump Winget Releaser to v2 on `stable`

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -7,7 +7,7 @@ jobs:
   publish:
     runs-on: windows-latest # Action can only be run on windows
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@v1
+      - uses: vedantmgoyal2009/winget-releaser@v2
         with:
           identifier: ArmCord.ArmCord
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Continuation of #357. I just noticed the latest release ran on v1.