### PR TITLE
Change Winget Releaser job to `ubuntu-latest`

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish:
-    runs-on: windows-latest # Action can only be run on windows
+    runs-on: ubuntu-latest
     steps:
       - uses: vedantmgoyal2009/winget-releaser@v2
         with:


### PR DESCRIPTION
Winget Releaser now supports non-Windows runners, and `ubuntu-latest` is generally faster.