### PR TITLE
fix transparency on linux

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -78,6 +78,7 @@ if (!app.requestSingleInstanceLock() && getConfigSync("multiInstance") == (false
         "disable-features",
         "WinRetrieveSuggestionsOnlyOnDemand,HardwareMediaKeyHandling,MediaSessionService"
     );
+    app.commandLine.appendSwitch("enable-transparent-visuals");
     checkForDataFolder();
     checkIfConfigExists();
     injectElectronFlags();

--- a/src/main.ts
+++ b/src/main.ts
@@ -113,7 +113,8 @@ if (!app.requestSingleInstanceLock() && getConfigSync("multiInstance") == (false
                     break;
             }
         }
-        await init();
+        // Patch for linux bug to insure things are loaded before window creation (fixes transparency on some linux systems)
+        await setTimeout(init, 500);
         await installModLoader();
         session.fromPartition("some-partition").setPermissionRequestHandler((_webContents, permission, callback) => {
             if (permission === "notifications") {

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -21,7 +21,7 @@
                 <option value="" disabled selected hidden data-string="settings-theme"></option>
                 <option value="default" data-string="settings-theme-default"></option>
                 <option value="native" data-string="settings-theme-native"></option>
-                <option value="transparent" windows-exclusive data-string="settings-theme-transparent"></option>
+                <option value="transparent" data-string="settings-theme-transparent"></option>
             </select>
 
             <p class="header" data-string="settings-theme"></p>

--- a/src/window.ts
+++ b/src/window.ts
@@ -352,6 +352,7 @@ export async function createTransparentWindow(): Promise<void> {
         icon: iconPath,
         frame: true,
         backgroundColor: "#00000000",
+        transparent: true,
         show: false,
         autoHideMenuBar: true,
         webPreferences: {


### PR DESCRIPTION
Even when I set the theme to transparent in my config file, the window still isn't transparent.
After this change, it is.

I only tested this on Linux (wayland, Hyprland), so I am not sure if this can break something on another platform. Also, maybe if this is done then the transparent option should be selectable on Linux?