### PR TITLE
fix: settings and info not appearing

### DIFF
--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -73,10 +73,7 @@ sleep(5000).then(async () => {
 
 // Settings info version injection
 setInterval(() => {
-    // @ts-expect-error
-    const host = [...document.querySelectorAll('[class*="sidebar"] [class*="info"] [class*="line"]')].find((x) =>
-        x.textContent.startsWith("Host ")
-    );
+    const host = document.querySelector('[class*="sidebar"] [class*="info"]');
     if (!host || host.querySelector("#ac-ver")) {
         return;
     }


### PR DESCRIPTION
Looks like discord might have changed something or we were just querying the wrong div the whole time
This queries the right div, making it able for the rest of the code to run :3

closes #502 
closes #491 