### PR TITLE
Add a menu item and keyboard shortcut to allow resetting the applications zoom level

### DIFF
--- a/src/menu.ts
+++ b/src/menu.ts
@@ -104,7 +104,9 @@ export async function setMenu(): Promise<void> {
                 // Fix for zoom in on keyboards with dedicated + like QWERTZ (or numpad)
                 // See https://github.com/electron/electron/issues/14742 and https://github.com/electron/electron/issues/5256
                 {label: "Zoom in", accelerator: "CmdOrCtrl+=", role: "zoomIn", visible: false},
-                {label: "Zoom out", accelerator: "CmdOrCtrl+-", role: "zoomOut"}
+                {label: "Zoom out", accelerator: "CmdOrCtrl+-", role: "zoomOut"},
+                {type: "separator"},
+                {label: "Reset zoom", accelerator: "CmdOrCtrl+0", role: "resetZoom"}
             ]
         }
     ];


### PR DESCRIPTION
This PR exposes the existing `resetZoom` menu item role ([https://www.electronjs.org/docs/latest/api/menu-item](https://www.electronjs.org/docs/latest/api/menu-item)) to users via a new item in the "Zoom" menu and the common `ctrl`+`0` accelerator.

Not having this functionality was bothering me for a while, as it is commonplace in other applications of this kind.
I don't have much experience with electron projects, but reading into it, this looks like a minor change that shouldn't interfere with anything. It is building and working nicely on my end.