### PR TITLE
Fix build failure on PNPM version mismatch

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 node-linker=hoisted
 public-hoist-pattern=*
 shamefully-hoist=true
+package-manager-strict=false


### PR DESCRIPTION
Originally the build would just fail with
` ERR_PNPM_BAD_PM_VERSION  This project is configured to use v9.1.1 of pnpm. Your current pnpm is v9.1.2`

I'm unsure why you would want this alert for anything but major versions, but this PR outright disabled the version check build failure.

It still fires a warning, however.
` WARN  This project is configured to use v9.1.1 of pnpm. Your current pnpm is v9.1.2`
