### PR TITLE
Remove redundant code for saveSettings ipc call

### DIFF
--- a/src/discord/ipc.ts
+++ b/src/discord/ipc.ts
@@ -92,9 +92,6 @@ export function registerIpc(): void {
         app.relaunch();
         app.exit();
     });
-    ipcMain.on("saveSettings", (_event, args) => {
-        setConfigBulk(args);
-    });
     ipcMain.on("minimizeToTray", async (event) => {
         event.returnValue = await getConfig("minimizeToTray");
     });


### PR DESCRIPTION
this part gets redefined later here:
https://github.com/ArmCord/ArmCord/blob/36e5f9570580bd61c3a4c630911eade31fd59a98/src/discord/ipc.ts#L136-L139

one of these parts can be removed i think, just happened to notice this.