### PR TITLE
use shelter injector integration instead of the plugin APIs

### DIFF
--- a/src/discord/preload/mods/shelter.ts
+++ b/src/discord/preload/mods/shelter.ts
@@ -3,13 +3,10 @@ import type { ModBundle } from "../../../@types/ModBundle.js";
 
 const requiredPlugins: Record<string, [string, { isVisible: boolean; allowedActions: Record<string, true> }]> = {
     // "armcord-arrpc": "armcord://plugins/armcordRPC/",
-    "armcord-settings": [
-        "armcord://plugins/armcordSettings/",
-        { isVisible: false, allowedActions: {} }
-    ],
+    "armcord-settings": ["armcord://plugins/armcordSettings/", { isVisible: false, allowedActions: {} }],
     "armcord-screenshare": [
         "armcord://plugins/screenshareQualityFix/",
-        { isVisible: true, allowedActions: { toggle: true } }
+        { isVisible: true, allowedActions: { toggle: true } },
     ],
 };
 try {

--- a/src/discord/preload/mods/shelter.ts
+++ b/src/discord/preload/mods/shelter.ts
@@ -1,45 +1,26 @@
 import { ipcRenderer, webFrame } from "electron";
 import type { ModBundle } from "../../../@types/ModBundle.js";
-import { sleep } from "../../../common/sleep.js";
-const requiredPlugins: Record<string, string> = {
+
+const requiredPlugins: Record<string, [string, { isVisible: boolean; allowedActions: Record<string, true> }]> = {
     // "armcord-arrpc": "armcord://plugins/armcordRPC/",
-    "armcord-settings": "armcord://plugins/armcordSettings/",
-    "armcord-screenshare": "armcord://plugins/screenshareQualityFix/",
+    "armcord-settings": [
+        "armcord://plugins/armcordSettings/",
+        { isVisible: false, allowedActions: {} }
+    ],
+    "armcord-screenshare": [
+        "armcord://plugins/screenshareQualityFix/",
+        { isVisible: true, allowedActions: { toggle: true } }
+    ],
 };
 try {
     await ipcRenderer.invoke("getShelterBundle").then(async (bundle: ModBundle) => {
         if (bundle.enabled) {
-            await webFrame.executeJavaScript(bundle.js);
+            await webFrame.executeJavaScript(`(()=>{
+                const SHELTER_INJECTOR_PLUGINS = ${JSON.stringify(requiredPlugins)};
+                ${bundle.js}
+            })()`);
         }
     });
 } catch (e) {
     console.error(e);
 }
-async function addPlugins() {
-    await sleep(5000).then(async () => {
-        for (const plugin in requiredPlugins) {
-            console.log(`${plugin}: ${requiredPlugins[plugin]}`);
-            const js = `
-            async function install() {
-                var installed = shelter.plugins.installedPlugins();
-                if (installed["${plugin}"]) {
-                    window.shelter.plugins.startPlugin("${plugin}");
-                } else {
-                    window.shelter.plugins.addRemotePlugin(
-                        "${plugin}",
-                        "${requiredPlugins[plugin]}"
-                    );
-                    await new Promise(r => setTimeout(r, 2000));
-                    window.shelter.plugins.startPlugin("${plugin}");
-            }}
-            install()
-        `;
-            try {
-                await webFrame.executeJavaScript(js);
-            } catch (_e) {
-                console.log(`Plugin ${plugin} already injected`);
-            }
-        }
-    });
-}
-void addPlugins();


### PR DESCRIPTION
This change uses the newly added [injector integration](https://shelter.uwu.network/guides/injectors) to load the built in shelter plugins. This gives the following benefits:
- plugin loading is more robust: plugin loading no longer requires on sleeping for periods of time and querying the plugin APIs, as injector plugins are integrated into the plugin loading and mod initialisation sequences, and can handle all cases cleanly.
- the settings are always shown above shelter settings, and never get mixed with plugin settings (which looks bad)
- the settings plugin is hidden from view as there is no benefit to allowing the user to see it
- the screenshare fix plugin now cannot be edited or deleted, but can still be toggled on and off by the user, and have its settings accessed

These particular settings seemed reasonable to me but are configurable.

A fresh install of Armcord now looks like this:
![image](https://github.com/user-attachments/assets/b171e339-82e7-494f-b601-02010372ca92)

As opposed to like this:
![image](https://github.com/user-attachments/assets/bc514242-0835-483b-a298-4b6e3a969be8)


And some demo screenshots showing the fixed settings injection behaviour, before / after:
![image](https://github.com/user-attachments/assets/fb611ccb-a73b-4fd6-abd8-4fa3efd07c44)
![image](https://github.com/user-attachments/assets/995cabe2-2dab-467f-b841-500a43f4a9da)
