### PR TITLE
Fix code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/src/discord/window.ts
+++ b/src/discord/window.ts
@@ -104,8 +104,8 @@ function doAfterDefiningTheWindow(passedWindow: BrowserWindow): void {
     passedWindow.webContents.on("frame-created", (_, { frame }) => {
         frame.once("dom-ready", async () => {
             if (
-                frame.url.includes("youtube.com/embed/") ||
-                (frame.url.includes("discordsays") && frame.url.includes("youtube.com"))
+                new URL(frame.url).hostname.endsWith("youtube.com") ||
+                (frame.url.includes("discordsays") && new URL(frame.url).hostname.endsWith("youtube.com"))
             ) {
                 await frame.executeJavaScript(fs.readFileSync(path.join(__dirname, "js/adguard.js"), "utf-8"));
             }


### PR DESCRIPTION
Fixes [https://github.com/ArmCord/ArmCord/security/code-scanning/1](https://github.com/ArmCord/ArmCord/security/code-scanning/1)

To fix the problem, we need to parse the URL and check the host value instead of using a substring check. This ensures that the check is performed on the actual host of the URL, preventing bypasses through embedding the substring in other parts of the URL.

1. Parse the URL using the `url` module to extract the host.
2. Check if the host matches "youtube.com" or any of its subdomains.
3. Replace the substring check with this more robust validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
