### PR TITLE
Bump Winget Releaser to `main`

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -6,7 +6,7 @@ jobs:
     publish:
         runs-on: windows-latest
         steps:
-            - uses: vedantmgoyal9/winget-releaser@v2
+            - uses: vedantmgoyal9/winget-releaser@main
               with:
                 identifier: smartfrigde.Legcord
                 token: ${{secrets.PUBLIC_REPO_READ}}


### PR DESCRIPTION
`v2` has not been updated for a year (still uses the old komac version), and the examples in the readme now use the main branch instead