### PR TITLE
ci(winget): match architecture-specific installers

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -9,4 +9,5 @@ jobs:
             - uses: vedantmgoyal9/winget-releaser@main
               with:
                 identifier: smartfrigde.Legcord
+                installers-regex: '-win-\w+\.exe$'
                 token: ${{secrets.PUBLIC_REPO_READ}}


### PR DESCRIPTION
Created a PR for 1.0.5 on winget-pkgs to reflect this change (should also fix the workflow errors):
- https://github.com/microsoft/winget-pkgs/pull/195077