### PR TITLE
fixes: settings, screensharing and more

### DIFF
--- a/electron-builder.ts
+++ b/electron-builder.ts
@@ -48,7 +48,16 @@ export const config: Configuration = {
         },
     },
 
-    files: ["!*", "assets", "node-modules", "ts-out", "package.json", "license.txt"],
+    files: [
+        "!*",
+        "assets",
+        "node-modules",
+        "ts-out",
+        "dist/venmic-arm64.node",
+        "dist/venmic-x64.node",
+        "package.json",
+        "license.txt",
+    ],
 
     electronDownload: {
         cache: ".cache",

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -124,7 +124,7 @@ export function checkIfConfigIsBroken(): void {
         configWasFine = missingKeysInSettings.length === 0;
         missingKeysInSettings.forEach((missingKey) => {
             console.log(`Missing config root entry ${missingKey}, setting default config for this entry...`);
-            setConfig(missingKey, settingsObject[missingKey]);
+            setConfig(missingKey, defaults[missingKey]);
         });
         console.log(configWasFine ? "Config is fine" : "Config is now fine");
     } catch (e) {

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -97,35 +97,56 @@ export function checkIfConfigExists(): void {
         console.log("Created missing user data folder");
     }
 
-    if (!existsSync(settingsFile)) {
-        if (!existsSync(storagePath)) {
-            mkdirSync(storagePath);
-            console.log("Created missing storage folder");
+    try {
+        if (!existsSync(settingsFile)) {
+            if (!existsSync(storagePath)) {
+                mkdirSync(storagePath);
+                console.log("Created missing storage folder");
+            }
+            console.log("First run of the Legcord. Starting setup.");
+            setup();
+            firstRun = true;
+        } else if (!getConfig("doneSetup")) {
+            console.log("First run of the Legcord. Starting setup.");
+            setup();
+            firstRun = true;
+        } else {
+            console.log("Legcord has been run before. Skipping setup.");
         }
-        console.log("First run of the Legcord. Starting setup.");
-        setup();
-        firstRun = true;
-    } else if (getConfig("doneSetup") === false) {
-        console.log("First run of the Legcord. Starting setup.");
-        setup();
-        firstRun = true;
-    } else {
-        console.log("Legcord has been run before. Skipping setup.");
+    } catch {
+        checkIfConfigIsBroken();
     }
 }
 export function checkIfConfigIsBroken(): void {
     try {
         const settingsData = readFileSync(getConfigLocation(), "utf-8");
         const settingsObject = JSON.parse(settingsData) as Settings;
+
         let configWasFine = true;
         const settingsKeys = Object.keys(settingsObject) as (keyof Settings)[];
         const defaultKeys = Object.keys(defaults) as (keyof Settings)[];
+
         const missingKeysInSettings = defaultKeys.filter((key) => !settingsKeys.includes(key));
         configWasFine = missingKeysInSettings.length === 0;
+
+        defaultKeys.forEach((key: keyof Settings) => {
+            const valueInSettings = settingsObject[key];
+            const valueInDefaults = defaults[key];
+            if (!valueInSettings || !valueInDefaults) return;
+            if (typeof valueInDefaults !== typeof valueInSettings) {
+                console.log(
+                    `Root config ${key} type (${typeof valueInSettings}) differs from default type (${typeof valueInDefaults}). Setting default value...`,
+                );
+                setConfig(key, valueInDefaults);
+                configWasFine = false;
+            }
+        });
+
         missingKeysInSettings.forEach((missingKey) => {
             console.log(`Missing config root entry ${missingKey}, setting default config for this entry...`);
             setConfig(missingKey, defaults[missingKey]);
         });
+
         console.log(configWasFine ? "Config is fine" : "Config is now fine");
     } catch (e) {
         console.error(e);

--- a/src/discord/preload/patches.mts
+++ b/src/discord/preload/patches.mts
@@ -14,28 +14,29 @@ export async function getVirtmic() {
 }
 
 async function load() {
-    const original = navigator.mediaDevices.getDisplayMedia;
-    navigator.mediaDevices.getDisplayMedia = async function (opts) {
-        const stream = await original.call(this, opts);
-        const id = await getVirtmic();
-
-        if (id) {
-            const audio = await navigator.mediaDevices.getUserMedia({
-                audio: {
-                    deviceId: {
-                        exact: id,
-                    },
-                    autoGainControl: false,
-                    echoCancellation: false,
-                    noiseSuppression: false,
-                },
-            });
-            audio.getAudioTracks().forEach((t) => stream.addTrack(t));
-        }
-
-        return stream;
-    };
     await sleep(5000).then(() => {
+        const original = navigator.mediaDevices.getDisplayMedia;
+        navigator.mediaDevices.getDisplayMedia = async function (opts) {
+            const stream = await original.call(this, opts);
+            const id = await getVirtmic();
+
+            if (id) {
+                const audio = await navigator.mediaDevices.getUserMedia({
+                    audio: {
+                        deviceId: {
+                            exact: id,
+                        },
+                        autoGainControl: false,
+                        echoCancellation: false,
+                        noiseSuppression: false,
+                    },
+                });
+                audio.getAudioTracks().forEach((t) => stream.addTrack(t));
+            }
+
+            return stream;
+        };
+
         // dirty hack to make clicking notifications focus Legcord
         addScript(`
         (() => {

--- a/src/shelter/screenshare/components/ScreensharePicker.tsx
+++ b/src/shelter/screenshare/components/ScreensharePicker.tsx
@@ -19,6 +19,38 @@ const {
     plugin: { store },
 } = shelter;
 
+export async function getVirtmic() {
+    try {
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        const audioDevice = devices.find(({ label }) => label === "vencord-screen-share");
+        return audioDevice?.deviceId;
+    } catch (error) {
+        return null;
+    }
+}
+function patchNavigator() {
+    const original = navigator.mediaDevices.getDisplayMedia;
+    navigator.mediaDevices.getDisplayMedia = async function (opts) {
+        const stream = await original.call(this, opts);
+        const id = await getVirtmic();
+        if (id) {
+            const audio = await navigator.mediaDevices.getUserMedia({
+                audio: {
+                    deviceId: {
+                        exact: id,
+                    },
+                    autoGainControl: false,
+                    echoCancellation: false,
+                    noiseSuppression: false,
+                },
+            });
+            audio.getAudioTracks().forEach((t) => stream.addTrack(t));
+        }
+
+        return stream;
+    };
+}
+
 export const ScreensharePicker = (props: {
     close: () => void;
     sources: IPCSources[];
@@ -40,7 +72,11 @@ export const ScreensharePicker = (props: {
         if (audioSource() !== undefined && audio()) {
             if (audioSource()!["node.name"] !== "Venmic disabled") {
                 console.info("audio venmic module source:", audioSource());
-                window.legcord.screenshare.venmicStart([audioSource()!]);
+                window.legcord.screenshare.venmicStart([audioSource()!]).then((done) => {
+                    if (done) {
+                        patchNavigator();
+                    }
+                });
             }
         }
         window.legcord.screenshare.start(source(), name(), audio());

--- a/src/shelter/screenshare/components/ScreensharePicker.tsx
+++ b/src/shelter/screenshare/components/ScreensharePicker.tsx
@@ -111,9 +111,7 @@ export const ScreensharePicker = (props: {
                         </div>
                     </div>
 
-                    <Show when={
-                                    window.legcord.platform === "linux" && props.audioSources !== undefined && audio()
-                                }>
+                    <Show when={window.legcord.platform === "linux" && props.audioSources !== undefined && audio()}>
                         <Divider mt mb />
                         <Header tag={HeaderTags.H4}>Venmic</Header>
                         <Dropdown


### PR DESCRIPTION
- fix: missing settings not being applied
- fixed venmic neither stopping nor closing audio connection/loopback after screensharing ends.
- improved bitrate to account for poor connections or oscilations (might change later).
- fixed venmic module not being included in the electron-builder bundle process, leading to venmic never being available when building.
- moved the patch for the `navigator.mediaDevices.getDisplayMedia` function so it happens after 5 seconds, and also when screensharing, so discord don't re-apply it when ending and starting another screenshare on the same voice channel.
- check for config entries object types and catch exceptions when reading `getConfig("doneSetup")`