### PR TITLE
fix: move package tsx to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "@rollup/plugin-esm-shim": "^0.1.7",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.0",
+        "@rollup/plugin-replace": "^6.0.2",
         "@rollup/plugin-typescript": "^12.1.1",
         "@types/node": "^22.10.1",
         "@types/ws": "^8.5.13",
@@ -48,9 +49,9 @@
         "rollup": "^4.27.4",
         "rollup-plugin-copy": "^3.5.0",
         "rollup-plugin-esbuild": "^6.1.1",
-        "@rollup/plugin-replace": "^6.0.2",
         "solid-js": "^1.9.3",
         "solid-motionone": "^1.0.3",
+        "tsx": "^4.19.2",
         "typescript": "^5.7.2"
     },
     "dependencies": {
@@ -58,7 +59,6 @@
         "electron-context-menu": "^4.0.4",
         "electron-is-dev": "^3.0.1",
         "electron-updater": "^6.3.9",
-        "tsx": "^4.19.2",
         "ws": "^8.18.0"
     },
     "optionalDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       electron-updater:
         specifier: ^6.3.9
         version: 6.3.9
-      tsx:
-        specifier: ^4.19.2
-        version: 4.19.2
       ws:
         specifier: ^8.18.0
         version: 8.18.0
@@ -94,6 +91,9 @@ importers:
       solid-motionone:
         specifier: ^1.0.3
         version: 1.0.3(solid-js@1.9.3)
+      tsx:
+        specifier: ^4.19.2
+        version: 4.19.2
       typescript:
         specifier: ^5.7.2
         version: 5.7.2


### PR DESCRIPTION
Introduced on #819 the `tsx` the package, as far as I can see/tell, is only used on development.

It adds `esbuild` as peerDependency and it has around 20MiB.

Moving it to `devDependencies` it can be pruned by `pnpm prune --prod`.