### PR TITLE
Fix traffic lights not being centered with "overlay"

### DIFF
--- a/src/discord/window.ts
+++ b/src/discord/window.ts
@@ -357,7 +357,7 @@ export function createWindow() {
                 height: 30,
             };
             browserWindowOptions.trafficLightPosition = {
-                x: 13,
+                x: 10,
                 y: 10,
             };
             break;


### PR DESCRIPTION
### Before

![2025-03-09 11-35-43 UTC@2x](https://github.com/user-attachments/assets/812d5b20-4b11-4767-b395-f9c34e815bad)

### After

![2025-03-09 11-33-49 UTC@2x](https://github.com/user-attachments/assets/b2c1cdf3-5c3b-4697-828b-edc2857c0d2f)

This also seems to match Discord's spacing.