### PR TITLE
fix: better selector for version injecting + bypassSetup flag

### DIFF
--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -179,3 +179,7 @@ export function setup(): void {
         ...defaults,
     });
 }
+
+export function setFirstRun(value: boolean): void {
+    firstRun = value;
+}

--- a/src/discord/preload/patches.mts
+++ b/src/discord/preload/patches.mts
@@ -65,9 +65,15 @@ async function load() {
     // Settings info version injection
     setInterval(() => {
         const host = document.querySelector('[class*="sidebar"] [class*="info"]');
-        if (!host || host.querySelector("#ac-ver") || !document.title.includes("| User Settings")) {
+        if (!host || host.querySelector("#ac-ver")) {
             return;
         }
+
+        const discordVersionInfoPattern = /(stable|ptb|canary) \d+|Electron|Chromium/i;
+        if (!discordVersionInfoPattern.test(host.textContent || "")) {
+            return;
+        }
+
         const el = host.firstElementChild!.cloneNode() as HTMLSpanElement;
         el.id = "ac-ver";
         el.textContent = `Legcord Version: ${version}`;

--- a/src/discord/preload/patches.mts
+++ b/src/discord/preload/patches.mts
@@ -65,7 +65,7 @@ async function load() {
     // Settings info version injection
     setInterval(() => {
         const host = document.querySelector('[class*="sidebar"] [class*="info"]');
-        if (!host || host.querySelector("#ac-ver")) {
+        if (!host || host.querySelector("#ac-ver") || !document.title.includes("| User Settings")) {
             return;
         }
         const el = host.firstElementChild!.cloneNode() as HTMLSpanElement;

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,8 +12,8 @@ import {
     getConfig,
     getConfigLocation,
     setConfig,
-    setup,
     setFirstRun,
+    setup,
 } from "./common/config.js";
 import "./updater.js";
 import { getPreset } from "./common/flags.js";

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,8 @@ import {
     getConfig,
     getConfigLocation,
     setConfig,
+    setup,
+    setFirstRun,
 } from "./common/config.js";
 import "./updater.js";
 import { getPreset } from "./common/flags.js";
@@ -21,6 +23,7 @@ import { createWindow } from "./discord/window.js";
 import { createSetupWindow } from "./setup/main.js";
 import { createSplashWindow } from "./splash/main.js";
 export let settings: Settings;
+export let bypassSetup = false;
 checkForDataFolder();
 checkIfConfigExists();
 
@@ -30,6 +33,16 @@ app.on("render-process-gone", (_event, _webContents, details) => {
     }
 });
 function args(): void {
+    // check for bypass-setup flag
+    if (process.argv.includes("--bypass-setup")) {
+        console.log("Bypassing setup and generating default config...");
+        setup(); // default settings
+        setConfig("doneSetup", true);
+        setFirstRun(false);
+        bypassSetup = true;
+        return;
+    }
+
     let argNum = 2;
     if (process.argv[0] === "electron") argNum++;
     const args = process.argv[argNum];
@@ -44,14 +57,15 @@ function args(): void {
     }
 }
 export async function init(): Promise<void> {
-    if (firstRun === true || undefined) {
-        setLang(new Intl.DateTimeFormat().resolvedOptions().locale);
-        await createSetupWindow();
-    } else {
+    // Skip setup if bypass flag was used
+    if (bypassSetup || !(firstRun === true || undefined)) {
         if (getConfig("skipSplash") === false) {
             void createSplashWindow(); // NOTE - Awaiting will hang at start
         }
         createWindow();
+    } else {
+        setLang(new Intl.DateTimeFormat().resolvedOptions().locale);
+        await createSetupWindow();
     }
 }
 args();


### PR DESCRIPTION
This PR fixes a little bug that was annoying me with the Legcord Version being injected under elements it shouldn't. For example, here in the profile sidebar inside a DM.

![image](https://github.com/user-attachments/assets/bb0ee097-49cb-4fc9-a0f7-27f799fb8bf8)

## After
![image](https://github.com/user-attachments/assets/6412016a-ae38-46cf-92c2-9fbf035437b5)

Still shows up in settings:
![image](https://github.com/user-attachments/assets/850e6572-3bc6-46cc-a198-9420132d4b9b)


I think there's other places I've observed this being injected throughout the app too over the past little while but I can't remember all edge cases. Just changes the injection selector to also check the child element for Discord version info, which ensures it's injected in the right place.

In addition I also added a `--bypass-setup` flag you can pass that bypasses setup in dev environments (bc the setup button wasn't working on my local dev). feel free to take this out if you dont want it, i just needed it to test locally.