### PR TITLE
fix(ci): push history to dev

### DIFF
--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -40,6 +40,6 @@ jobs:
 
                   git add meta/app.legcord.Legcord.metainfo.xml
                   git commit -m "metainfo: add entry for ${{ github.event.release.tag_name }}"
-                  git push
+                  git push origin HEAD:dev
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to specify the branch for pushing changes. 

Workflow update:

* [`.github/workflows/meta.yml`](diffhunk://#diff-55bdc7573163e0cd41d717bb944e5ce0a324ecf79d91449347b0b89d5f631379L43-R43): Changed the `git push` command to explicitly push to the `dev` branch instead of the default branch.