### PR TITLE
Fix: Dropdown module colors adapt to theme

### DIFF
--- a/src/shelter/settings/components/Dropdown.module.css
+++ b/src/shelter/settings/components/Dropdown.module.css
@@ -1,5 +1,5 @@
 .acDropdown option {
-    color: #fff;
+    color: var(--text-secondary);
     font-weight: 400;
     font-style: normal;
 }
@@ -18,7 +18,7 @@
     background-repeat: no-repeat;
     border: 1px solid var(--background-floating);
     border-radius: 2px;
-    color: #fff;
+    color: var(--text-default);
     font-size: 1.2em;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
Changed the text color of the module, so it appears as expected in light mode.

<h3>Before:</h3>
<img width="709" height="554" alt="{5BEA408A-122C-4F59-9334-220EAD82AA0A}" src="https://github.com/user-attachments/assets/6eec41d8-95e9-4acd-8897-b46908edbe90" />

<h3>After:</h3>
<img width="712" height="570" alt="{0BC554B7-4671-4236-B2F5-1F94B5CD3DDF}" src="https://github.com/user-attachments/assets/5900722e-d657-4e1f-bf92-326e135e6da8" />

