### PR TITLE
Fixed youtube adblock issue.

### DIFF
--- a/src/discord/window.ts
+++ b/src/discord/window.ts
@@ -105,7 +105,7 @@ function doAfterDefiningTheWindow(passedWindow: BrowserWindow): void {
                 frame.url.includes("youtube.com/embed/") ||
                 (frame.url.includes("discordsays") && frame.url.includes("youtube.com"))
             ) {
-                await frame.executeJavaScript(readFileSync(path.join(__dirname, "js/adguard.js"), "utf-8"));
+                await frame.executeJavaScript(readFileSync(path.join(__dirname, "assets/js/adguard.js"), "utf-8"));
             }
         });
     });


### PR DESCRIPTION
This issue was preventing users from playing videos trough embeds due to getting the adblock module from wrong path.

<img width="1527" height="384" alt="image" src="https://github.com/user-attachments/assets/6ac9dc36-c736-4919-8c14-8d1a226410bb" />
