### PR TITLE
fix: update css var names used on nav buttons

### DIFF
--- a/assets/app/css/baseTitlebar.css
+++ b/assets/app/css/baseTitlebar.css
@@ -47,6 +47,6 @@
     height: 100%;
     width: 33.3%;
     text-align: center;
-    color: var(--interactive-normal);
+    color: var(--interactive-icon-default);
     cursor: default;
 }

--- a/assets/app/css/darwinTitlebar.css
+++ b/assets/app/css/darwinTitlebar.css
@@ -59,9 +59,9 @@
     background-color: #fac536;
     transition: background-color 0.1s ease-in;
     border: 1px solid #da9e10;
-    -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='13' height='13'%3E%3Cstyle%3E.a%7Bfill:%23808080%7D%3C/style%3E%3Ccircle class='a' cx='15' cy='15' r='15'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='13' height='13'><style>.a%7Bfill:%23808080%7D</style><circle class='a' cx='15' cy='15' r='15'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='13' height='13'%3E%3Cstyle%3E.a%7Bfill:%23808080%7D%3C/style%3E%3Ccircle class='a' cx='15' cy='15' r='15'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='13' height='13'><style>.a%7Bfill:%23808080%7D</style><circle class='a' cx='15' cy='15' r='15'/></svg>")
         no-repeat 50% 50%;
     transform: translateX(-21.5px);
 }
@@ -69,9 +69,9 @@
     background-color: #39ea49;
     transition: background-color 0.1s ease-in;
     border: 1px solid #13c11e;
-    -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='13' height='13'%3E%3Cstyle%3E.a%7Bfill:%23808080%7D%3C/style%3E%3Ccircle class='a' cx='15' cy='15' r='15'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='13' height='13'><style>.a%7Bfill:%23808080%7D</style><circle class='a' cx='15' cy='15' r='15'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='13' height='13'%3E%3Cstyle%3E.a%7Bfill:%23808080%7D%3C/style%3E%3Ccircle class='a' cx='15' cy='15' r='15'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='13' height='13'><style>.a%7Bfill:%23808080%7D</style><circle class='a' cx='15' cy='15' r='15'/></svg>")
         no-repeat 50% 50%;
     transform: translateX(21.5px);
 }
@@ -79,9 +79,9 @@
     background-color: #f25056;
     transition: background-color 0.1s ease-in;
     border: 1px solid #d52735;
-    -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='13' height='13'%3E%3Cstyle%3E.a%7Bfill:%23808080%7D%3C/style%3E%3Ccircle class='a' cx='15' cy='15' r='15'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='13' height='13'><style>.a%7Bfill:%23808080%7D</style><circle class='a' cx='15' cy='15' r='15'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='13' height='13'%3E%3Cstyle%3E.a%7Bfill:%23808080%7D%3C/style%3E%3Ccircle class='a' cx='15' cy='15' r='15'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='13' height='13'><style>.a%7Bfill:%23808080%7D</style><circle class='a' cx='15' cy='15' r='15'/></svg>")
         no-repeat 50% 50%;
 }
 [legcord-platform="darwin"] #window-controls-container:hover #maximize:active {

--- a/assets/app/css/linuxTitlebar.css
+++ b/assets/app/css/linuxTitlebar.css
@@ -6,19 +6,19 @@
     width: 142px;
 }
 [legcord-platform="linux"] #window-controls-container #minimize:hover {
-    background-color: var(--background-modifier-hover);
+    background-color: var(--interactive-background-hover);
     transition: 0.2s ease;
 }
 [legcord-platform="linux"] #window-controls-container #maximize:hover {
-    background-color: var(--background-modifier-hover);
+    background-color: var(--interactive-background-hover);
     transition: 0.2s ease;
 }
 [legcord-platform="linux"] #window-controls-container #minimize:hover #minimize-icon {
-    background-color: var(--interactive-hover);
+    background-color: var(--interactive-text-hover);
     transition: 0.2s ease;
 }
 [legcord-platform="linux"] #window-controls-container #maximize:hover #maximize-icon {
-    background-color: var(--interactive-hover);
+    background-color: var(--interactive-text-hover);
     transition: 0.2s ease;
 }
 [legcord-platform="linux"] #window-controls-container #quit:hover {
@@ -50,35 +50,35 @@
     transition: 0.1s ease;
 }
 [legcord-platform="linux"] #window-controls-container #quit-icon {
-    background-color: var(--interactive-normal);
+    background-color: var(--interactive-icon-default);
     display: list-item;
-    -webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6.279 5.5L11 10.221l-.779.779L5.5 6.279.779 11 0 10.221 4.721 5.5 0 .779.779 0 5.5 4.721 10.221 0 11 .779 6.279 5.5z' fill='%23000'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml;charset=utf-8,<svg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M6.279 5.5L11 10.221l-.779.779L5.5 6.279.779 11 0 10.221 4.721 5.5 0 .779.779 0 5.5 4.721 10.221 0 11 .779 6.279 5.5z' fill='%23000'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6.279 5.5L11 10.221l-.779.779L5.5 6.279.779 11 0 10.221 4.721 5.5 0 .779.779 0 5.5 4.721 10.221 0 11 .779 6.279 5.5z' fill='%23000'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml;charset=utf-8,<svg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M6.279 5.5L11 10.221l-.779.779L5.5 6.279.779 11 0 10.221 4.721 5.5 0 .779.779 0 5.5 4.721 10.221 0 11 .779 6.279 5.5z' fill='%23000'/></svg>")
         no-repeat 50% 50%;
 }
 [legcord-platform="linux"] #window-controls-container #minimize-icon {
-    background-color: var(--interactive-normal);
+    background-color: var(--interactive-icon-default);
     display: list-item;
-    -webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11 4.399V5.5H0V4.399h11z' fill='%23000'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml;charset=utf-8,<svg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M11 4.399V5.5H0V4.399h11z' fill='%23000'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11 4.399V5.5H0V4.399h11z' fill='%23000'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml;charset=utf-8,<svg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M11 4.399V5.5H0V4.399h11z' fill='%23000'/></svg>")
         no-repeat 50% 50%;
 }
 [legcord-platform="linux"] #window-controls-container #maximize-icon {
-    background-color: var(--interactive-normal);
+    background-color: var(--interactive-icon-default);
     display: list-item;
-    -webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11 0v11H0V0h11zM9.899 1.101H1.1V9.9h8.8V1.1z' fill='%23000'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml;charset=utf-8,<svg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M11 0v11H0V0h11zM9.899 1.101H1.1V9.9h8.8V1.1z' fill='%23000'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11 0v11H0V0h11zM9.899 1.101H1.1V9.9h8.8V1.1z' fill='%23000'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml;charset=utf-8,<svg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M11 0v11H0V0h11zM9.899 1.101H1.1V9.9h8.8V1.1z' fill='%23000'/></svg>")
         no-repeat 50% 50%;
 }
 
 [legcord-platform="linux"][isMaximized] #window-controls-container #maximize-icon {
-    background-color: var(--interactive-normal);
+    background-color: var(--interactive-icon-default);
     display: list-item;
-    -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='11' height='11'%3E%3Cstyle%3E%3C/style%3E%3Cpath fill-rule='evenodd' d='m6 0h24v24h-6v6h-24v-24h6zm3 6h15v15h3v-18h-18zm-6 21h18v-18h-18z'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='11' height='11'><style></style><path fill-rule='evenodd' d='m6 0h24v24h-6v6h-24v-24h6zm3 6h15v15h3v-18h-18zm-6 21h18v-18h-18z'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='11' height='11'%3E%3Cstyle%3E%3C/style%3E%3Cpath fill-rule='evenodd' d='m6 0h24v24h-6v6h-24v-24h6zm3 6h15v15h3v-18h-18zm-6 21h18v-18h-18z'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='11' height='11'><style></style><path fill-rule='evenodd' d='m6 0h24v24h-6v6h-24v-24h6zm3 6h15v15h3v-18h-18zm-6 21h18v-18h-18z'/></svg>")
         no-repeat 50% 50%;
 }

--- a/assets/app/css/titlebar.css
+++ b/assets/app/css/titlebar.css
@@ -38,7 +38,7 @@
     height: 100%;
     width: 33.3%;
     text-align: center;
-    color: var(--interactive-normal);
+    color: var(--interactive-icon-default);
     cursor: default;
 }
 .titlebar #window-controls-container #spacer {
@@ -59,19 +59,19 @@
     transform: translateY(-8px);
 }
 [legcord-platform="linux"] .titlebar #window-controls-container #minimize:hover {
-    background-color: var(--background-modifier-hover);
+    background-color: var(--interactive-background-hover);
     transition: 0.2s ease;
 }
 [legcord-platform="linux"] .titlebar #window-controls-container #maximize:hover {
-    background-color: var(--background-modifier-hover);
+    background-color: var(--interactive-background-hover);
     transition: 0.2s ease;
 }
 [legcord-platform="linux"] .titlebar #window-controls-container #minimize:hover #minimize-icon {
-    background-color: var(--interactive-hover);
+    background-color: var(--interactive-text-hover);
     transition: 0.2s ease;
 }
 [legcord-platform="linux"] .titlebar #window-controls-container #maximize:hover #maximize-icon {
-    background-color: var(--interactive-hover);
+    background-color: var(--interactive-text-hover);
     transition: 0.2s ease;
 }
 [legcord-platform="linux"] .titlebar #window-controls-container #quit:hover {
@@ -82,58 +82,58 @@
     background-color: #ffffff;
     display: list-item;
     transition: 0.1s ease;
-    -webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='9' height='9' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6.279 5.5L11 10.221l-.779.779L5.5 6.279.779 11 0 10.221 4.721 5.5 0 .779.779 0 5.5 4.721 10.221 0 11 .779 6.279 5.5z' fill='%23000'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml;charset=utf-8,<svg width='9' height='9' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M6.279 5.5L11 10.221l-.779.779L5.5 6.279.779 11 0 10.221 4.721 5.5 0 .779.779 0 5.5 4.721 10.221 0 11 .779 6.279 5.5z' fill='%23000'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='9' height='9' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6.279 5.5L11 10.221l-.779.779L5.5 6.279.779 11 0 10.221 4.721 5.5 0 .779.779 0 5.5 4.721 10.221 0 11 .779 6.279 5.5z' fill='%23000'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml;charset=utf-8,<svg width='9' height='9' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M6.279 5.5L11 10.221l-.779.779L5.5 6.279.779 11 0 10.221 4.721 5.5 0 .779.779 0 5.5 4.721 10.221 0 11 .779 6.279 5.5z' fill='%23000'/></svg>")
         no-repeat 50% 50%;
 }
 [legcord-platform="linux"] .titlebar #window-controls-container #minimize-icon {
-    background-color: var(--interactive-normal);
+    background-color: var(--interactive-icon-default);
     display: list-item;
-    -webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='9' height='9' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11 4.399V5.5H0V4.399h11z' fill='%23000'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml;charset=utf-8,<svg width='9' height='9' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M11 4.399V5.5H0V4.399h11z' fill='%23000'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='9' height='9' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11 4.399V5.5H0V4.399h11z' fill='%23000'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml;charset=utf-8,<svg width='9' height='9' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M11 4.399V5.5H0V4.399h11z' fill='%23000'/></svg>")
         no-repeat 50% 50%;
 }
 [legcord-platform="linux"] .titlebar #window-controls-container #maximize-icon {
-    background-color: var(--interactive-normal);
+    background-color: var(--interactive-icon-default);
     display: list-item;
-    -webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='9' height='9' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11 0v11H0V0h11zM9.899 1.101H1.1V9.9h8.8V1.1z' fill='%23000'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml;charset=utf-8,<svg width='9' height='9' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M11 0v11H0V0h11zM9.899 1.101H1.1V9.9h8.8V1.1z' fill='%23000'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='9' height='9' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11 0v11H0V0h11zM9.899 1.101H1.1V9.9h8.8V1.1z' fill='%23000'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml;charset=utf-8,<svg width='9' height='9' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M11 0v11H0V0h11zM9.899 1.101H1.1V9.9h8.8V1.1z' fill='%23000'/></svg>")
         no-repeat 50% 50%;
 }
 
 [legcord-platform="linux"][isMaximized] .titlebar #window-controls-container #maximize-icon {
-    background-color: var(--interactive-normal);
+    background-color: var(--interactive-icon-default);
     display: list-item;
-    -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='9' height='9'%3E%3Cstyle%3E%3C/style%3E%3Cpath fill-rule='evenodd' d='m6 0h24v24h-6v6h-24v-24h6zm3 6h15v15h3v-18h-18zm-6 21h18v-18h-18z'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='9' height='9'><style></style><path fill-rule='evenodd' d='m6 0h24v24h-6v6h-24v-24h6zm3 6h15v15h3v-18h-18zm-6 21h18v-18h-18z'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='9' height='9'%3E%3Cstyle%3E%3C/style%3E%3Cpath fill-rule='evenodd' d='m6 0h24v24h-6v6h-24v-24h6zm3 6h15v15h3v-18h-18zm-6 21h18v-18h-18z'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='9' height='9'><style></style><path fill-rule='evenodd' d='m6 0h24v24h-6v6h-24v-24h6zm3 6h15v15h3v-18h-18zm-6 21h18v-18h-18z'/></svg>")
         no-repeat 50% 50%;
 }
 [legcord-platform="linux"] .titlebar #window-controls-container #minimize {
     background-color: transparent;
     transition: 0.1s ease;
-    -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='25' height='25'%3E%3Cstyle%3E.a%7Bfill:%23808080%7D%3C/style%3E%3Ccircle class='a' cx='15' cy='15' r='15'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='25' height='25'><style>.a%7Bfill:%23808080%7D</style><circle class='a' cx='15' cy='15' r='15'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='25' height='25'%3E%3Cstyle%3E.a%7Bfill:%23808080%7D%3C/style%3E%3Ccircle class='a' cx='15' cy='15' r='15'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='25' height='25'><style>.a%7Bfill:%23808080%7D</style><circle class='a' cx='15' cy='15' r='15'/></svg>")
         no-repeat 50% 50%;
 }
 [legcord-platform="linux"] .titlebar #window-controls-container #maximize {
     background-color: transparent;
     transition: 0.1s ease;
-    -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='25' height='25'%3E%3Cstyle%3E.a%7Bfill:%23808080%7D%3C/style%3E%3Ccircle class='a' cx='15' cy='15' r='15'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='25' height='25'><style>.a%7Bfill:%23808080%7D</style><circle class='a' cx='15' cy='15' r='15'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='25' height='25'%3E%3Cstyle%3E.a%7Bfill:%23808080%7D%3C/style%3E%3Ccircle class='a' cx='15' cy='15' r='15'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='25' height='25'><style>.a%7Bfill:%23808080%7D</style><circle class='a' cx='15' cy='15' r='15'/></svg>")
         no-repeat 50% 50%;
 }
 [legcord-platform="linux"] .titlebar #window-controls-container #quit {
     background-color: var(--brand-experiment);
     transition: 0.1s ease;
-    -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='25' height='25'%3E%3Cstyle%3E.a%7Bfill:%23808080%7D%3C/style%3E%3Ccircle class='a' cx='15' cy='15' r='15'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='25' height='25'><style>.a%7Bfill:%23808080%7D</style><circle class='a' cx='15' cy='15' r='15'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='25' height='25'%3E%3Cstyle%3E.a%7Bfill:%23808080%7D%3C/style%3E%3Ccircle class='a' cx='15' cy='15' r='15'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='25' height='25'><style>.a%7Bfill:%23808080%7D</style><circle class='a' cx='15' cy='15' r='15'/></svg>")
         no-repeat 50% 50%;
 }
 [legcord-platform="linux"] .titlebar #window-controls-container #quit:active {
@@ -146,19 +146,19 @@
     width: 142px;
 }
 [legcord-platform="win32"] .titlebar #window-controls-container #minimize:hover {
-    background-color: var(--background-modifier-hover);
+    background-color: var(--interactive-background-hover);
     transition: 0.2s ease;
 }
 [legcord-platform="win32"] .titlebar #window-controls-container #maximize:hover {
-    background-color: var(--background-modifier-hover);
+    background-color: var(--interactive-background-hover);
     transition: 0.2s ease;
 }
 [legcord-platform="win32"] .titlebar #window-controls-container #minimize:hover #minimize-icon {
-    background-color: var(--interactive-hover);
+    background-color: var(--interactive-text-hover);
     transition: 0.2s ease;
 }
 [legcord-platform="win32"] .titlebar #window-controls-container #maximize:hover #maximize-icon {
-    background-color: var(--interactive-hover);
+    background-color: var(--interactive-text-hover);
     transition: 0.2s ease;
 }
 [legcord-platform="win32"] .titlebar #window-controls-container #quit:hover {
@@ -190,36 +190,36 @@
     transition: 0.1s ease;
 }
 [legcord-platform="win32"] .titlebar #window-controls-container #quit-icon {
-    background-color: var(--interactive-normal);
+    background-color: var(--interactive-icon-default);
     display: list-item;
-    -webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6.279 5.5L11 10.221l-.779.779L5.5 6.279.779 11 0 10.221 4.721 5.5 0 .779.779 0 5.5 4.721 10.221 0 11 .779 6.279 5.5z' fill='%23000'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml;charset=utf-8,<svg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M6.279 5.5L11 10.221l-.779.779L5.5 6.279.779 11 0 10.221 4.721 5.5 0 .779.779 0 5.5 4.721 10.221 0 11 .779 6.279 5.5z' fill='%23000'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6.279 5.5L11 10.221l-.779.779L5.5 6.279.779 11 0 10.221 4.721 5.5 0 .779.779 0 5.5 4.721 10.221 0 11 .779 6.279 5.5z' fill='%23000'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml;charset=utf-8,<svg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M6.279 5.5L11 10.221l-.779.779L5.5 6.279.779 11 0 10.221 4.721 5.5 0 .779.779 0 5.5 4.721 10.221 0 11 .779 6.279 5.5z' fill='%23000'/></svg>")
         no-repeat 50% 50%;
 }
 [legcord-platform="win32"] .titlebar #window-controls-container #minimize-icon {
-    background-color: var(--interactive-normal);
+    background-color: var(--interactive-icon-default);
     display: list-item;
-    -webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11 4.399V5.5H0V4.399h11z' fill='%23000'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml;charset=utf-8,<svg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M11 4.399V5.5H0V4.399h11z' fill='%23000'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11 4.399V5.5H0V4.399h11z' fill='%23000'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml;charset=utf-8,<svg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M11 4.399V5.5H0V4.399h11z' fill='%23000'/></svg>")
         no-repeat 50% 50%;
 }
 [legcord-platform="win32"] .titlebar #window-controls-container #maximize-icon {
-    background-color: var(--interactive-normal);
+    background-color: var(--interactive-icon-default);
     display: list-item;
-    -webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11 0v11H0V0h11zM9.899 1.101H1.1V9.9h8.8V1.1z' fill='%23000'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml;charset=utf-8,<svg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M11 0v11H0V0h11zM9.899 1.101H1.1V9.9h8.8V1.1z' fill='%23000'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11 0v11H0V0h11zM9.899 1.101H1.1V9.9h8.8V1.1z' fill='%23000'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml;charset=utf-8,<svg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M11 0v11H0V0h11zM9.899 1.101H1.1V9.9h8.8V1.1z' fill='%23000'/></svg>")
         no-repeat 50% 50%;
 }
 
 [legcord-platform="win32"][isMaximized] .titlebar #window-controls-container #maximize-icon {
-    background-color: var(--interactive-normal);
+    background-color: var(--interactive-icon-default);
     display: list-item;
-    -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='11' height='11'%3E%3Cstyle%3E%3C/style%3E%3Cpath fill-rule='evenodd' d='m6 0h24v24h-6v6h-24v-24h6zm3 6h15v15h3v-18h-18zm-6 21h18v-18h-18z'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='11' height='11'><style></style><path fill-rule='evenodd' d='m6 0h24v24h-6v6h-24v-24h6zm3 6h15v15h3v-18h-18zm-6 21h18v-18h-18z'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='11' height='11'%3E%3Cstyle%3E%3C/style%3E%3Cpath fill-rule='evenodd' d='m6 0h24v24h-6v6h-24v-24h6zm3 6h15v15h3v-18h-18zm-6 21h18v-18h-18z'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='11' height='11'><style></style><path fill-rule='evenodd' d='m6 0h24v24h-6v6h-24v-24h6zm3 6h15v15h3v-18h-18zm-6 21h18v-18h-18z'/></svg>")
         no-repeat 50% 50%;
 }
 
@@ -290,9 +290,9 @@
     background-color: #fac536;
     transition: background-color 0.1s ease-in;
     border: 1px solid #da9e10;
-    -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='13' height='13'%3E%3Cstyle%3E.a%7Bfill:%23808080%7D%3C/style%3E%3Ccircle class='a' cx='15' cy='15' r='15'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='13' height='13'><style>.a%7Bfill:%23808080%7D</style><circle class='a' cx='15' cy='15' r='15'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='13' height='13'%3E%3Cstyle%3E.a%7Bfill:%23808080%7D%3C/style%3E%3Ccircle class='a' cx='15' cy='15' r='15'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='13' height='13'><style>.a%7Bfill:%23808080%7D</style><circle class='a' cx='15' cy='15' r='15'/></svg>")
         no-repeat 50% 50%;
     transform: translateX(-21.5px);
 }
@@ -300,9 +300,9 @@
     background-color: #39ea49;
     transition: background-color 0.1s ease-in;
     border: 1px solid #13c11e;
-    -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='13' height='13'%3E%3Cstyle%3E.a%7Bfill:%23808080%7D%3C/style%3E%3Ccircle class='a' cx='15' cy='15' r='15'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='13' height='13'><style>.a%7Bfill:%23808080%7D</style><circle class='a' cx='15' cy='15' r='15'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='13' height='13'%3E%3Cstyle%3E.a%7Bfill:%23808080%7D%3C/style%3E%3Ccircle class='a' cx='15' cy='15' r='15'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='13' height='13'><style>.a%7Bfill:%23808080%7D</style><circle class='a' cx='15' cy='15' r='15'/></svg>")
         no-repeat 50% 50%;
     transform: translateX(21.5px);
 }
@@ -310,9 +310,9 @@
     background-color: #f25056;
     transition: background-color 0.1s ease-in;
     border: 1px solid #d52735;
-    -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='13' height='13'%3E%3Cstyle%3E.a%7Bfill:%23808080%7D%3C/style%3E%3Ccircle class='a' cx='15' cy='15' r='15'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='13' height='13'><style>.a%7Bfill:%23808080%7D</style><circle class='a' cx='15' cy='15' r='15'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='13' height='13'%3E%3Cstyle%3E.a%7Bfill:%23808080%7D%3C/style%3E%3Ccircle class='a' cx='15' cy='15' r='15'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='13' height='13'><style>.a%7Bfill:%23808080%7D</style><circle class='a' cx='15' cy='15' r='15'/></svg>")
         no-repeat 50% 50%;
 }
 [legcord-platform="darwin"] .titlebar #window-controls-container:hover #maximize:active {

--- a/assets/app/css/winTitlebar.css
+++ b/assets/app/css/winTitlebar.css
@@ -8,19 +8,19 @@
     width: 142px;
 }
 [legcord-platform="win32"] #window-controls-container #minimize:hover {
-    background-color: var(--background-modifier-hover);
+    background-color: var(--interactive-background-hover);
     transition: 0.2s ease;
 }
 [legcord-platform="win32"] #window-controls-container #maximize:hover {
-    background-color: var(--background-modifier-hover);
+    background-color: var(--interactive-background-hover);
     transition: 0.2s ease;
 }
 [legcord-platform="win32"] #window-controls-container #minimize:hover #minimize-icon {
-    background-color: var(--interactive-hover);
+    background-color: var(--interactive-text-hover);
     transition: 0.2s ease;
 }
 [legcord-platform="win32"] #window-controls-container #maximize:hover #maximize-icon {
-    background-color: var(--interactive-hover);
+    background-color: var(--interactive-text-hover);
     transition: 0.2s ease;
 }
 [legcord-platform="win32"] #window-controls-container #quit:hover {
@@ -52,35 +52,35 @@
     transition: 0.1s ease;
 }
 [legcord-platform="win32"] #window-controls-container #quit-icon {
-    background-color: var(--interactive-normal);
+    background-color: var(--interactive-icon-default);
     display: list-item;
-    -webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6.279 5.5L11 10.221l-.779.779L5.5 6.279.779 11 0 10.221 4.721 5.5 0 .779.779 0 5.5 4.721 10.221 0 11 .779 6.279 5.5z' fill='%23000'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml;charset=utf-8,<svg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M6.279 5.5L11 10.221l-.779.779L5.5 6.279.779 11 0 10.221 4.721 5.5 0 .779.779 0 5.5 4.721 10.221 0 11 .779 6.279 5.5z' fill='%23000'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6.279 5.5L11 10.221l-.779.779L5.5 6.279.779 11 0 10.221 4.721 5.5 0 .779.779 0 5.5 4.721 10.221 0 11 .779 6.279 5.5z' fill='%23000'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml;charset=utf-8,<svg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M6.279 5.5L11 10.221l-.779.779L5.5 6.279.779 11 0 10.221 4.721 5.5 0 .779.779 0 5.5 4.721 10.221 0 11 .779 6.279 5.5z' fill='%23000'/></svg>")
         no-repeat 50% 50%;
 }
 [legcord-platform="win32"] #window-controls-container #minimize-icon {
-    background-color: var(--interactive-normal);
+    background-color: var(--interactive-icon-default);
     display: list-item;
-    -webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11 4.399V5.5H0V4.399h11z' fill='%23000'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml;charset=utf-8,<svg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M11 4.399V5.5H0V4.399h11z' fill='%23000'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11 4.399V5.5H0V4.399h11z' fill='%23000'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml;charset=utf-8,<svg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M11 4.399V5.5H0V4.399h11z' fill='%23000'/></svg>")
         no-repeat 50% 50%;
 }
 [legcord-platform="win32"] #window-controls-container #maximize-icon {
-    background-color: var(--interactive-normal);
+    background-color: var(--interactive-icon-default);
     display: list-item;
-    -webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11 0v11H0V0h11zM9.899 1.101H1.1V9.9h8.8V1.1z' fill='%23000'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml;charset=utf-8,<svg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M11 0v11H0V0h11zM9.899 1.101H1.1V9.9h8.8V1.1z' fill='%23000'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11 0v11H0V0h11zM9.899 1.101H1.1V9.9h8.8V1.1z' fill='%23000'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml;charset=utf-8,<svg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M11 0v11H0V0h11zM9.899 1.101H1.1V9.9h8.8V1.1z' fill='%23000'/></svg>")
         no-repeat 50% 50%;
 }
 
 [legcord-platform="win32"][isMaximized] #window-controls-container #maximize-icon {
-    background-color: var(--interactive-normal);
+    background-color: var(--interactive-icon-default);
     display: list-item;
-    -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='11' height='11'%3E%3Cstyle%3E%3C/style%3E%3Cpath fill-rule='evenodd' d='m6 0h24v24h-6v6h-24v-24h6zm3 6h15v15h3v-18h-18zm-6 21h18v-18h-18z'/%3E%3C/svg%3E")
+    -webkit-mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='11' height='11'><style></style><path fill-rule='evenodd' d='m6 0h24v24h-6v6h-24v-24h6zm3 6h15v15h3v-18h-18zm-6 21h18v-18h-18z'/></svg>")
         no-repeat 50% 50%;
-    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='11' height='11'%3E%3Cstyle%3E%3C/style%3E%3Cpath fill-rule='evenodd' d='m6 0h24v24h-6v6h-24v-24h6zm3 6h15v15h3v-18h-18zm-6 21h18v-18h-18z'/%3E%3C/svg%3E")
+    mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' width='11' height='11'><style></style><path fill-rule='evenodd' d='m6 0h24v24h-6v6h-24v-24h6zm3 6h15v15h3v-18h-18zm-6 21h18v-18h-18z'/></svg>")
         no-repeat 50% 50%;
 }

--- a/src/shelter/settings/components/KeybindCard.module.css
+++ b/src/shelter/settings/components/KeybindCard.module.css
@@ -21,12 +21,12 @@
 .btn {
     border: none;
     background: none;
-    color: var(--interactive-active);
+    color: var(--interactive-text-active);
 
     transition: opacity 250ms;
 
     &:hover {
-        color: var(--interactive-hover);
+        color: var(--interactive-text-hover);
     }
 }
 

--- a/src/shelter/settings/components/ThemesCard.module.css
+++ b/src/shelter/settings/components/ThemesCard.module.css
@@ -20,12 +20,12 @@
 .btn {
     border: none;
     background: none;
-    color: var(--interactive-active);
+    color: var(--interactive-text-active);
 
     transition: opacity 250ms;
 
     &:hover {
-        color: var(--interactive-hover);
+        color: var(--interactive-text-hover);
     }
 }
 


### PR DESCRIPTION
Don't know when exactly this change was implemented, but it appears Discord changed the names of a few css variables that Legcord relied on for styling some buttons, which in the case of the nav buttons made them invisible. It might be worth adding a backup color for where used so in future cases nav buttons are still visible.

Additionally in the svgs, changed `<` and `>` to their ascii form rather than their url encoded form `%3C`, `%3E`.

Haven't tested the changes on other platforms aside from Linux yet, but I don't see why these changes shouldn't work on them.

closes #988 