### PR TITLE
fix: Equicord Headerbar button overlap

### DIFF
--- a/assets/app/css/linuxTitlebar.css
+++ b/assets/app/css/linuxTitlebar.css
@@ -1,4 +1,4 @@
-[legcord-platform="linux"] a[href="https://support.discord.com"] {
+[legcord-platform="linux"] div[class^="trailing_"] {
     margin-right: 150px;
 }
 

--- a/assets/app/css/winTitlebar.css
+++ b/assets/app/css/winTitlebar.css
@@ -1,6 +1,6 @@
 /* Legcord on Windows */
 
-[legcord-platform="win32"] a[href="https://support.discord.com"] {
+[legcord-platform="win32"] div[class^="trailing_"] {
     margin-right: 150px;
 }
 

--- a/src/shelter/titlebar/index.ts
+++ b/src/shelter/titlebar/index.ts
@@ -24,7 +24,7 @@ function injectButtonControls() {
     const elem = document.createElement("div");
     elem.innerHTML = titlebarNavControls;
     elem.id = "legcordNavControls";
-    document.body.prepend(elem);
+    document.body.append(elem);
     const minimize = document.getElementById("minimize");
     const maximize = document.getElementById("maximize");
     const quit = document.getElementById("quit");


### PR DESCRIPTION
Equicord added a new Headerbar API which allows plugins to easily add buttons to the headerbar, however with how Legcord places the navigation buttons, the new Equicord buttons overlap with the nav buttons.

Without fix (with #989):
<img width="1023" height="28" alt="image" src="https://github.com/user-attachments/assets/182f2df1-10c6-4ae5-bc4a-60dd8bf49731" />

With fix (and #989):
<img width="1014" height="29" alt="image" src="https://github.com/user-attachments/assets/f104731c-5144-4522-a79a-a356be60734e" />

This change rather than looking for the support button, just finds the trailing headerbar div. Changed to append to body rather than prepend as otherwise the nav buttons are not clickable.