### PR TITLE
Fix trailing bar collision with nav bar

### DIFF
--- a/assets/app/css/linuxTitlebar.css
+++ b/assets/app/css/linuxTitlebar.css
@@ -1,4 +1,4 @@
-[legcord-platform="linux"] div[class^="trailing_"] {
+[legcord-platform="linux"] div[class*="title"] + div[class*="trailing"] {
     margin-right: 150px;
 }
 

--- a/assets/app/css/winTitlebar.css
+++ b/assets/app/css/winTitlebar.css
@@ -1,6 +1,6 @@
 /* Legcord on Windows */
 
-[legcord-platform="win32"] div[class^="trailing_"] {
+[legcord-platform="win32"] div[class*="title"] + div[class*="trailing"] {
     margin-right: 150px;
 }
 


### PR DESCRIPTION
Appears Discord changed the classname of the trailing bar since #990 was merged (to personally spite me I'm sure), so change to the [wildcard attribute selector](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/Attribute_selectors#attrvalue_6) on `trailing`. I felt that might be too broad of a selector, I increased the specificity by using the [next sibling selector](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/Next-sibling_combinator).

I could have changed the selector to `[class$="trailing"]` as `trailing` is the suffix now, but the wildcard selector felt a bit more "future-proof".

before:
<img width="198" height="32" alt="image" src="https://github.com/user-attachments/assets/c25406f7-5163-499a-8d9c-b907ac8ecf7f" />
after:
<img width="328" height="36" alt="image" src="https://github.com/user-attachments/assets/a8f1519d-09db-4107-a32f-449afd59da49" />
