### PR TITLE
Fix YouTube embeds in chat and watch together activity

### DIFF
--- a/src/discord/window.ts
+++ b/src/discord/window.ts
@@ -184,8 +184,8 @@ function doAfterDefiningTheWindow(passedWindow: BrowserWindow): void {
     // fix UMG video playback
     passedWindow.webContents.session.webRequest.onBeforeSendHeaders(
         { urls: ["https://www.youtube.com/embed/*"] },
-        ({ requestHeaders, url }, callback) => {
-            requestHeaders.Referer = url;
+        ({ requestHeaders }, callback) => {
+            requestHeaders.Referer = "https://google.com";
             callback({ requestHeaders });
         },
     );

--- a/src/shelter/settings/components/DropdownItem.module.css
+++ b/src/shelter/settings/components/DropdownItem.module.css
@@ -1,6 +1,6 @@
 .note {
     margin-top: 8px;
-    color: var(--header-secondary);
+    color: var(--text-subtle);
     font-size: 14px;
     line-height: 20px;
     font-weight: 400;
@@ -11,7 +11,7 @@
     display: block;
     overflow: hidden;
     margin: 0;
-    color: var(--header-primary);
+    color: var(--text-strong);
     line-height: 24px;
     font-weight: 500;
     word-wrap: break-word;


### PR DESCRIPTION
I noticed that YouTube embeds in chat weren't loading properly ("152 - 4" error code).
I tracked it down to an issue with the "Referer" request header in the embed request; it seems like YouTube blocks embedding from "youtube.com".
Removing the "onBeforeSendHeaders" hook or changing the URL for the "Referer" header fixes embeds, but breaks the UMG unblocking. Changing the header to "google.com" fixes embeds and allows UMG videos to embed.