### PR TITLE
improved the keybind maker

### DIFF
--- a/src/shelter/settings/components/KeybindMaker.module.css
+++ b/src/shelter/settings/components/KeybindMaker.module.css
@@ -11,3 +11,12 @@
     right: 0;
     transform: translate(-7px, -50%);
 }
+.error {
+    color: var(--control-critical-secondary-text-default);
+    font-size: 14px;
+    line-height: 20px;
+    font-weight: 400;
+
+    margin: 0;
+    margin-left: 5px;
+}

--- a/src/shelter/settings/components/KeybindMaker.module.css
+++ b/src/shelter/settings/components/KeybindMaker.module.css
@@ -1,5 +1,13 @@
 .grabBox {
+    position: relative;
     flex-direction: row;
     flex: 1;
     display: flex;
+}
+.recBtn {
+    position: absolute;
+    width: auto;
+    top: 50%;
+    right: 0;
+    transform: translate(-7px, -50%);
 }

--- a/src/shelter/settings/components/KeybindMaker.tsx
+++ b/src/shelter/settings/components/KeybindMaker.tsx
@@ -1,4 +1,4 @@
-import { Show, createSignal } from "solid-js";
+import { Show, createSignal, onCleanup } from "solid-js";
 import type { KeybindActions } from "../../../@types/keybind.js";
 import { Dropdown } from "./Dropdown.jsx";
 import classes from "./KeybindMaker.module.css";
@@ -41,17 +41,18 @@ export const KeybindMaker = (props: { close: () => void }) => {
             logged.unshift(key);
             setAccelerator(logged.join("+"));
         }
-        if(timeout) clearInterval(timeout);
+        if(timeout) clearTimeout(timeout);
         timeout = setTimeout(stopRecording, 3000);
     };
     function stopRecording() {
         if (!recording()) return;
         setRecording(false);
-        if(timeout) clearInterval(timeout);
+        if(timeout) clearTimeout(timeout);
 
         document.body.removeEventListener("keyup", log);
         console.log("Recording stop");
     };
+    onCleanup(() => recording() && stopRecording());
 
     function startRecording() {
         if (recording()) return;

--- a/src/shelter/settings/components/KeybindMaker.tsx
+++ b/src/shelter/settings/components/KeybindMaker.tsx
@@ -2,6 +2,7 @@ import { Show, createSignal } from "solid-js";
 import type { KeybindActions } from "../../../@types/keybind.js";
 import { Dropdown } from "./Dropdown.jsx";
 import classes from "./KeybindMaker.module.css";
+
 const {
     ui: {
         ModalRoot,
@@ -12,56 +13,57 @@ const {
         TextBox,
         Button,
         ButtonSizes,
+        ButtonColors,
         Header,
         HeaderTags,
         Divider,
         SwitchItem,
-        genId,
-        showToast,
+        genId
     },
     plugin: { store },
 } = shelter;
+
 export const KeybindMaker = (props: { close: () => void }) => {
+    const [recording, setRecording] = createSignal(false);
     const [accelerator, setAccelerator] = createSignal("");
     const [global, setGlobal] = createSignal(true);
     const [action, setAction] = createSignal<KeybindActions>("mute");
     const [javascriptCode, setJavascriptCode] = createSignal("");
     const [enabled, setEnabled] = createSignal(true);
-    let logged: string[] = [];
-    let lock = false;
-    function grabKeys() {
-        if (lock) return;
-        lock = true;
+
+    let logged: string[] = [], timeout: NodeJS.Timeout | null = null;
+    function log(event: KeyboardEvent) {
+        const key = event.key.replace(" ", "Space");
+        if (logged.includes(key) || logged.length > 3) {
+            console.log("already in array");
+        } else {
+            console.log(key);
+            logged.unshift(key);
+            setAccelerator(logged.join("+"));
+        }
+        if(timeout) clearInterval(timeout);
+        timeout = setTimeout(stopRecording, 3000);
+    };
+    function stopRecording() {
+        if (!recording()) return;
+        setRecording(false);
+        if(timeout) clearInterval(timeout);
+
+        document.body.removeEventListener("keyup", log);
+        console.log("Recording stop");
+    };
+
+    function startRecording() {
+        if (recording()) return;
+        setRecording(true);
+
         logged = [];
         setAccelerator("");
         console.log("Recording start");
-        document.body.addEventListener("keyup", function log(event) {
-            const key = event.key;
-            if (logged.includes(key) || logged.length > 3) {
-                console.log("already in array");
-            } else {
-                key.replace(" ", "Space");
-                console.log(key);
-                logged.push(key);
-                setAccelerator(`${key}+${accelerator()}`);
-            }
-            setTimeout(() => {
-                if (lock) {
-                    lock = false;
-                    document.body.removeEventListener("keyup", log);
-                    console.log("Recording stop");
-                    setAccelerator(accelerator().slice(0, -1));
-                }
-            }, 3000);
-        });
+        document.body.addEventListener("keyup", log);
     }
     function save() {
-        if (lock)
-            return showToast({
-                title: "Slow down!",
-                content: "Pause for a few seconds after recording a keybind before saving it.",
-                duration: 3000,
-            });
+        if (recording()) stopRecording();
         if (accelerator() === "") return;
         const current = store.settings.keybinds;
         const keybind = {
@@ -78,6 +80,7 @@ export const KeybindMaker = (props: { close: () => void }) => {
         console.log(store.settings.keybinds);
         window.legcord.settings.addKeybind(keybind);
     }
+
     return (
         <ModalRoot size={ModalSizes.SMALL}>
             <ModalHeader close={props.close}>Add a keybind</ModalHeader>
@@ -87,9 +90,16 @@ export const KeybindMaker = (props: { close: () => void }) => {
                     {/* FIXME -  I have no idea what this `disabled` tag is, its not in the typedefs 
                     // @ts-expect-error*/}
                     <TextBox disabled value={accelerator()} onInput={setAccelerator} />
-                    <Button onClick={grabKeys} size={ButtonSizes.MEDIUM}>
-                        Record
-                    </Button>
+                    { 
+                        recording() ?
+                            <Button class={classes.recBtn} onClick={stopRecording} size={ButtonSizes.SMALL} color={ButtonColors.RED}>
+                                Recording
+                            </Button>
+                        :
+                            <Button class={classes.recBtn} onClick={startRecording} size={ButtonSizes.SMALL}>
+                                Record
+                            </Button>
+                    }
                 </div>
                 <Divider mt mb />
                 <Header tag={HeaderTags.H5}>Action</Header>

--- a/src/shelter/settings/components/KeybindMaker.tsx
+++ b/src/shelter/settings/components/KeybindMaker.tsx
@@ -47,7 +47,10 @@ export const KeybindMaker = (props: { close: () => void }) => {
     function stopRecording() {
         if (!recording()) return;
         setRecording(false);
-        if(timeout) clearTimeout(timeout);
+        if(timeout) {
+            clearTimeout(timeout);
+            timeout = null;
+        };
 
         document.body.removeEventListener("keyup", log);
         console.log("Recording stop");

--- a/src/shelter/settings/components/KeybindMaker.tsx
+++ b/src/shelter/settings/components/KeybindMaker.tsx
@@ -31,7 +31,9 @@ export const KeybindMaker = (props: { close: () => void }) => {
     const [javascriptCode, setJavascriptCode] = createSignal("");
     const [enabled, setEnabled] = createSignal(true);
 
-    let logged: string[] = [], timeout: NodeJS.Timeout | null = null;
+    let logged: string[] = [];
+    let containsNonModifier = false;
+    let timeout: NodeJS.Timeout | null = null;
     function log(event: KeyboardEvent) {
         const key = event.key.replace(" ", "Space");
         if (logged.includes(key) || logged.length > 3) {
@@ -39,6 +41,7 @@ export const KeybindMaker = (props: { close: () => void }) => {
         } else {
             console.log(key);
             logged.unshift(key);
+            if(event.location == 0) containsNonModifier = true;
             setAccelerator(logged.join("+"));
         }
         if(timeout) clearTimeout(timeout);
@@ -62,6 +65,7 @@ export const KeybindMaker = (props: { close: () => void }) => {
         setRecording(true);
 
         logged = [];
+        containsNonModifier = false;
         setAccelerator("");
         console.log("Recording start");
         document.body.addEventListener("keyup", log);
@@ -89,7 +93,14 @@ export const KeybindMaker = (props: { close: () => void }) => {
         <ModalRoot size={ModalSizes.SMALL}>
             <ModalHeader close={props.close}>Add a keybind</ModalHeader>
             <ModalBody>
-                <Header tag={HeaderTags.H5}>Accelerator</Header>
+                <span style="display: flex">
+                    <Header tag={HeaderTags.H5}>
+                        Accelerator
+                    </Header>
+                    <Show when={!recording() && accelerator() && !containsNonModifier}>
+                        <p class={classes.error}>Modifier-only shortcuts are not supported.</p>
+                    </Show>
+                </span>
                 <div class={classes.grabBox}>
                     {/* FIXME -  I have no idea what this `disabled` tag is, its not in the typedefs 
                     // @ts-expect-error*/}
@@ -135,7 +146,7 @@ export const KeybindMaker = (props: { close: () => void }) => {
                     <TextBox value={javascriptCode()} onInput={setJavascriptCode} />
                 </Show>
             </ModalBody>
-            <ModalConfirmFooter confirmText="Add" onConfirm={save} close={props.close} />
+            <ModalConfirmFooter confirmText="Add" onConfirm={save} close={props.close} disabled={recording() || !accelerator() || !containsNonModifier} />
         </ModalRoot>
     );
 };

--- a/src/shelter/settings/components/KeybindMaker.tsx
+++ b/src/shelter/settings/components/KeybindMaker.tsx
@@ -71,8 +71,6 @@ export const KeybindMaker = (props: { close: () => void }) => {
         document.body.addEventListener("keyup", log);
     }
     function save() {
-        if (recording()) stopRecording();
-        if (accelerator() === "") return;
         const current = store.settings.keybinds;
         const keybind = {
             accelerator: accelerator(),


### PR DESCRIPTION
made the record button appear inside the accelerator text box (like the discord push to talk input)
made the button change colors to red while recording
removed trailing "+" while recording accelerator
made it so you can click the button while its recording to stop recording and removed the dialog for waiting before saving
addressed #938 by adding an error message since modifier only shortcuts arent supported by electron
disabled the "add" button when a valid accelerator isnt set