### PR TITLE
fixed a launch failure related to global shortcuts

### DIFF
--- a/src/discord/globalKeybinds.ts
+++ b/src/discord/globalKeybinds.ts
@@ -8,9 +8,11 @@ export function registerGlobalKeybinds() {
     const keybinds = getConfig("keybinds");
     keybinds.forEach((keybind: Keybind) => {
         if (keybind.enabled && keybind.global) {
-            globalShortcut.register(keybind.accelerator, () => {
-                runAction(keybind);
-            });
+            try {
+                globalShortcut.register(keybind.accelerator, () => {
+                    runAction(keybind);
+                });
+            } catch {}
         }
     });
 }

--- a/src/shelter/settings/components/KeybindMaker.tsx
+++ b/src/shelter/settings/components/KeybindMaker.tsx
@@ -94,7 +94,7 @@ export const KeybindMaker = (props: { close: () => void }) => {
                 <span style="display: flex">
                     <Header tag={HeaderTags.H5}>Accelerator</Header>
                     <Show when={!recording() && accelerator() && !containsNonModifier}>
-                        <p class={classes.error}>Modifier-only shortcuts are not supported.</p>
+                        <p class={classes.error}>This key combination is invalid or not supported.</p>
                     </Show>
                 </span>
                 <div class={classes.grabBox}>


### PR DESCRIPTION
added a try catch to the `globalShortcut.register` call to stop invalid keybinds from preventing the app from launching
generalized the invalid accelerator message
electron doesnt seem to support numpad keys at all for some reason, on their own or with other keys unlike modifier keys which only work with other keys

related issues:
#947
#968 and probably some other ones but this is the only one that explicitly mentions numpad keybinds