### PR TITLE
fixed a launch failure related to global shortcuts

### DIFF
--- a/src/discord/globalKeybinds.ts
+++ b/src/discord/globalKeybinds.ts
@@ -8,9 +8,11 @@ export function registerGlobalKeybinds() {
     const keybinds = getConfig("keybinds");
     keybinds.forEach((keybind: Keybind) => {
         if (keybind.enabled && keybind.global) {
-            globalShortcut.register(keybind.accelerator, () => {
-                runAction(keybind);
-            });
+            try {
+                globalShortcut.register(keybind.accelerator, () => {
+                    runAction(keybind);
+                });
+            } catch {}
         }
     });
 }

--- a/src/shelter/settings/components/KeybindMaker.tsx
+++ b/src/shelter/settings/components/KeybindMaker.tsx
@@ -33,6 +33,7 @@ export const KeybindMaker = (props: { close: () => void }) => {
 
     let logged: string[] = [];
     let containsNonModifier = false;
+    let containsNumpadKey = false;
     let timeout: NodeJS.Timeout | null = null;
     function log(event: KeyboardEvent) {
         const key = event.key.replace(" ", "Space");
@@ -41,7 +42,11 @@ export const KeybindMaker = (props: { close: () => void }) => {
         } else {
             console.log(key);
             logged.unshift(key);
-            if (event.location === 0) containsNonModifier = true;
+            if (event.location === 0) {
+                containsNonModifier = true;
+            } else if (event.location === 3) {
+                containsNumpadKey = true;
+            }
             setAccelerator(logged.join("+"));
         }
         if (timeout) clearTimeout(timeout);
@@ -66,6 +71,7 @@ export const KeybindMaker = (props: { close: () => void }) => {
 
         logged = [];
         containsNonModifier = false;
+        containsNumpadKey = false;
         setAccelerator("");
         console.log("Recording start");
         document.body.addEventListener("keyup", log);
@@ -93,7 +99,7 @@ export const KeybindMaker = (props: { close: () => void }) => {
             <ModalBody>
                 <span style="display: flex">
                     <Header tag={HeaderTags.H5}>Accelerator</Header>
-                    <Show when={!recording() && accelerator() && !containsNonModifier}>
+                    <Show when={containsNumpadKey || (!recording() && accelerator() && !containsNonModifier)}>
                         <p class={classes.error}>This key combination is invalid or not supported.</p>
                     </Show>
                 </span>
@@ -152,7 +158,7 @@ export const KeybindMaker = (props: { close: () => void }) => {
                 confirmText="Add"
                 onConfirm={save}
                 close={props.close}
-                disabled={recording() || !accelerator() || !containsNonModifier}
+                disabled={recording() || !accelerator() || !containsNonModifier || containsNumpadKey}
             />
         </ModalRoot>
     );

--- a/src/shelter/settings/components/KeybindMaker.tsx
+++ b/src/shelter/settings/components/KeybindMaker.tsx
@@ -94,7 +94,7 @@ export const KeybindMaker = (props: { close: () => void }) => {
                 <span style="display: flex">
                     <Header tag={HeaderTags.H5}>Accelerator</Header>
                     <Show when={!recording() && accelerator() && !containsNonModifier}>
-                        <p class={classes.error}>Modifier-only shortcuts are not supported.</p>
+                        <p class={classes.error}>This key combination is invalid or not supported.</p>
                     </Show>
                 </span>
                 <div class={classes.grabBox}>


### PR DESCRIPTION
added a try catch to the globalShortcut.register call to stop invalid keybinds from preventing the app from launching
generalized the invalid accelerator message
electron doesnt seem to support numpad keys at all for some reason, on their own or with other keys unlike modifier keys which only work with other keys

related issues:
#947
#968 and probably some other ones but this is the only one that explicitly mentions numpad keybinds