### PR TITLE
fix: Windows titlebar duplication

### DIFF
--- a/assets/app/css/winTitlebar.css
+++ b/assets/app/css/winTitlebar.css
@@ -1,11 +1,11 @@
 /* Legcord on Windows */
 
 [legcord-platform="win32"] div[class*="title"] + div[class*="trailing"] {
-    margin-right: 150px;
+    margin-right: 173px;
 }
 
 [legcord-platform="win32"] #window-controls-container {
-    width: 142px;
+    width: 165px;
 }
 [legcord-platform="win32"] #window-controls-container #minimize:hover {
     background-color: var(--interactive-background-hover);

--- a/src/discord/window.ts
+++ b/src/discord/window.ts
@@ -364,6 +364,11 @@ export function createWindow() {
         },
     };
     switch (getConfig("windowStyle")) {
+        case "default":
+            if (os.platform() === "win32") {
+                browserWindowOptions.titleBarStyle = "hidden";
+                browserWindowOptions.titleBarOverlay = false;
+            }
         case "native":
             browserWindowOptions.frame = true;
             break;
@@ -372,7 +377,7 @@ export function createWindow() {
             browserWindowOptions.titleBarOverlay = {
                 color: getConfig("overlayButtonColor"),
                 symbolColor: "#99aab5",
-                height: 36,
+                height: 30,
             };
             browserWindowOptions.trafficLightPosition = {
                 x: 10,


### PR DESCRIPTION
Modern Transparency on Windows leads to both a native and custom titlebar:
<img width="312" height="180" alt="doubling-default" src="https://github.com/user-attachments/assets/2b7154e6-270c-4c78-b389-f6250400fc7c" />
This fixes that and also resizes the buttons to match the native sizes better:
<img width="289" height="215" alt="fixed" src="https://github.com/user-attachments/assets/0418e550-1053-4099-8843-709e51aed677" />
