### PR TITLE
settings menu version patch fix

### DIFF
--- a/src/discord/preload/patches.mts
+++ b/src/discord/preload/patches.mts
@@ -63,21 +63,18 @@ async function load() {
     });
     injectJS("legcord://assets/js/patchVencordQuickCSS.js");
     // Settings info version injection
-    setInterval(() => {
-        const host = document.querySelector('[class*="sidebar"] [class*="info"]');
-        if (!host || host.querySelector("#ac-ver")) {
-            return;
-        }
+    const observer = new MutationObserver(() => {
+        if (document.querySelector("#ac-ver")) return;
 
-        const discordVersionInfoPattern = /(stable|ptb|canary) \d+|Electron|Chromium/i;
-        if (!discordVersionInfoPattern.test(host.textContent || "")) {
-            return;
-        }
+        const info = document.querySelector('[class*="sidebar"] [class*="compactInfo"]');
+        const host = info?.parentElement;
+        if (!host || !/(stable|ptb|canary) \d+|Electron|Chromium/i.test(host.textContent)) return;
 
-        const el = host.firstElementChild!.cloneNode() as HTMLSpanElement;
+        const el = host.querySelector("span")!.cloneNode() as HTMLSpanElement;
         el.id = "ac-ver";
         el.textContent = `Legcord Version: ${version}`;
-        host.append(el);
-    }, 1000);
+        info.after(el);
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
 }
 load();

--- a/src/discord/preload/patches.mts
+++ b/src/discord/preload/patches.mts
@@ -64,9 +64,9 @@ async function load() {
     injectJS("legcord://assets/js/patchVencordQuickCSS.js");
     // Settings info version injection
     const observer = new MutationObserver(() => {
-        if (document.querySelector("#ac-ver")) return;
+        if (document.body.querySelector("#ac-ver")) return;
 
-        const info = document.querySelector('[class*="sidebar"] [class*="compactInfo"]');
+        const info = document.body.querySelector('[class*="sidebar"] [class*="compactInfo"]');
         const host = info?.parentElement;
         if (!host || !/(stable|ptb|canary) \d+|Electron|Chromium/i.test(host.textContent)) return;
 


### PR DESCRIPTION
the new discord settings menu broke the legcord version patching
<img width="186" height="95" alt="image" src="https://github.com/user-attachments/assets/740936be-a3a2-455d-973b-3a80aed00f56" />

fix:
<img width="180" height="96" alt="image" src="https://github.com/user-attachments/assets/5e442a28-1037-4bc2-9781-f6f4eac51430" />
