### PR TITLE
fixed warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
         "@babel/preset-typescript": "^7.27.1",
         "@biomejs/biome": "1.9.4",
         "@rollup/plugin-babel": "^6.0.4",
-        "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-esm-shim": "^0.1.7",
         "@types/node": "^22.10.1",
         "@types/ws": "^8.5.13",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "@biomejs/biome": "1.9.4",
         "@rollup/plugin-babel": "^6.0.4",
         "@rollup/plugin-esm-shim": "^0.1.7",
+        "@types/minimatch": "^6.0.0",
         "@types/node": "^22.10.1",
         "@types/ws": "^8.5.13",
         "@uwu/lune": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "build:dev": "rollup -c --environment BUILD:dev && tsx scripts/copyVenmic.mts",
         "build:plugins": "lune ci --repoSubDir src/shelter --to ts-out/plugins",
         "build": "pnpm build:plugins && rolldown -c rolldown.config.js && tsx scripts/copyVenmic.mts",
-        "start": "pnpm build:plugins && pnpm run build && electron --trace-warnings --ozone-platform-hint=auto ./ts-out/main.js",
+        "start": "pnpm run build && electron --trace-warnings --ozone-platform-hint=auto ./ts-out/main.js",
         "startThemeManager": "pnpm run build:dev && electron ./ts-out/main.js themes",
         "package": "pnpm run build && electron-builder",
         "packageQuick": "pnpm run build && electron-builder --dir",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,9 +39,6 @@ importers:
       '@rollup/plugin-esm-shim':
         specifier: ^0.1.7
         version: 0.1.8
-      '@rollup/plugin-json':
-        specifier: ^6.1.0
-        version: 6.1.0
       '@types/node':
         specifier: ^22.10.1
         version: 22.19.7
@@ -996,15 +993,6 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/plugin-json@6.1.0':
-    resolution: {integrity: sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
@@ -1802,16 +1790,17 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-agent@3.0.0:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
@@ -2794,7 +2783,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.5.7:
     resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
@@ -3830,10 +3819,6 @@ snapshots:
     dependencies:
       magic-string: 0.30.21
       mlly: 1.8.0
-
-  '@rollup/plugin-json@6.1.0':
-    dependencies:
-      '@rollup/pluginutils': 5.3.0
 
   '@rollup/pluginutils@5.3.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@rollup/plugin-esm-shim':
         specifier: ^0.1.7
         version: 0.1.8
+      '@types/minimatch':
+        specifier: ^6.0.0
+        version: 6.0.0
       '@types/node':
         specifier: ^22.10.1
         version: 22.19.7

--- a/rolldown.config.js
+++ b/rolldown.config.js
@@ -45,7 +45,7 @@ export default defineConfig([
             format: "esm",
             sourcemap: true,
         },
-        external: [...electronExternals, "arrpc"],
+        external: [...electronExternals, "arrpc", "node:worker_threads"],
         plugins: [esmShim()],
     },
     {

--- a/rolldown.config.js
+++ b/rolldown.config.js
@@ -1,6 +1,5 @@
 import babel from "@rollup/plugin-babel";
 import esmShim from "@rollup/plugin-esm-shim";
-import json from "@rollup/plugin-json";
 import { defineConfig } from "rolldown";
 import copy from "rollup-plugin-copy";
 
@@ -28,7 +27,6 @@ export default defineConfig([
         ],
         plugins: [
             esmShim(),
-            json(),
             copy({
                 targets: [
                     { src: "src/**/**/*.html", dest: "ts-out/html/" },
@@ -48,7 +46,7 @@ export default defineConfig([
             sourcemap: true,
         },
         external: [...electronExternals, "arrpc"],
-        plugins: [esmShim(), json()],
+        plugins: [esmShim()],
     },
     {
         input: "src/discord/preload/preload.mts",


### PR DESCRIPTION
```
[PREFER_BUILTIN_FEATURE] Warning: The functionality provided by `@rollup/plugin-json` is already covered natively, maybe you could remove the plugin from your configuration.
```
removed plugin-json

```
src\rpc.ts (1:27) [UNRESOLVED_IMPORT] Warning: Could not resolve 'node:worker_threads' in src/rpc.ts
```
added "node:worker_threads" as an external to rolldown config

```
Cannot find type definition file for 'minimatch'.
  The file is in the program because:
    Entry point for implicit type library 'minimatch'
```
installed minimatch types