### PR TITLE
Disable CanvasOopRasterization to prevent GPU process crashes

### DIFF
--- a/src/common/flags.ts
+++ b/src/common/flags.ts
@@ -23,7 +23,6 @@ const performance: Preset = {
     ],
     enableFeatures: [
         "EnableDrDc",
-        "CanvasOopRasterization",
         "BackForwardCache:TimeToLiveInBackForwardCacheInSeconds/300/should_ignore_blocklists/true/enable_same_site/true",
         "ThrottleDisplayNoneAndVisibilityHiddenCrossOriginIframes",
         "UseSkiaRenderer",


### PR DESCRIPTION
Remove CanvasOopRasterization from the enabled feature list because 
it causes repeated GPU process crashes during initialization and rendering.

Observed errors include unexpected GPU process exit (code 34), 
CreateCommandBuffer transient failures, and video capture context 
binding failures.

Disabling OOP rasterization gets rid of this crash.