### PR TITLE
fix: StartupWMClass should be legcord

### DIFF
--- a/electron-builder.ts
+++ b/electron-builder.ts
@@ -29,6 +29,11 @@ export const config: Configuration = {
         target: ["AppImage", "deb", "rpm", "tar.gz"],
         maintainer: "linux@legcord.app",
         category: "Network",
+        desktop: {
+            entry: {
+                StartupWMClass: "legcord",
+            },
+        },
     },
 
     nsis: {


### PR DESCRIPTION
the default desktop entry uses the productName for StartupWMClass which results in `StartupWMClass=Legcord`.  The WM_CLASS should match the lowercase executable name (`legcord`) so window managers can match correctly.  electron-builder allows overriding with the `desktop`object

Before :
<img width="480" height="300" alt="Capture d’écran du 2026-02-22 20-06-20" src="https://github.com/user-attachments/assets/a24d15af-cb40-497e-970d-a8f80a7a5512" />

PR:
<img width="292" height="300" alt="Capture d’écran du 2026-02-22 20-11-06" src="https://github.com/user-attachments/assets/de65f76d-e0b6-42b2-a42a-d1ff67854b56" />
