### PR TITLE
fix: play sound effect on mute toggle

### DIFF
--- a/src/common/keybindActions.ts
+++ b/src/common/keybindActions.ts
@@ -53,7 +53,7 @@ export function muteToggle() {
                     "type": "AUDIO_TOGGLE_SELF_MUTE",
                     "context": "default",
                     "syncRemote": true,
-                    "skipMuteUnmuteSoundEffect": false
+                    "playSoundEffect": true
                 })
                 `);
     });


### PR DESCRIPTION
### Summary
Ensure the mute/unmute sound effect plays when triggering the mute
toggle keybind.

### Changes
- Replace `skipMuteUnmuteSoundEffect: false` with `playSoundEffect: true`
  in the `AUDIO_TOGGLE_SELF_MUTE` dispatcher payload.