### PR TITLE
fix: rpc not disappearing

### DIFF
--- a/src/shelter/rpc/index.ts
+++ b/src/shelter/rpc/index.ts
@@ -15,10 +15,10 @@ async function listen(msg: {
 }) {
     if (!window.legcordRPC) return;
 
-    // Handle game closing (activity: null) by dispatching update to clear status
+    // Handle game closing by dispatching update to clear status
     if (!msg.activity) {
         console.log("RPC activity cleared (game closed)");
-        FluxDispatcher.dispatch({ type: "LOCAL_ACTIVITY_UPDATE", activity: null });
+        FluxDispatcher.dispatch({ type: "LOCAL_ACTIVITY_UPDATE", ...msg });
         return;
     }
 
@@ -70,6 +70,7 @@ async function listen(msg: {
                 msg.activity.assets.small_image,
             );
     }
+
     console.log("RPC activity update", msg.activity);
     FluxDispatcher.dispatch({ type: "LOCAL_ACTIVITY_UPDATE", ...msg }); // set RPC status
 }


### PR DESCRIPTION
This closes https://github.com/Legcord/Legcord/issues/1022. The cause was that the "pid" and "socketId" values were missing in the activity clearing process.