### PR TITLE
chore: polish keybinds UI

### DIFF
--- a/src/shelter/settings/components/KeybindCard.module.css
+++ b/src/shelter/settings/components/KeybindCard.module.css
@@ -1,10 +1,13 @@
 .card {
-    border: 1px solid var(--background-accent);
-    border-radius: 4px;
-    padding: 0.5rem;
-    margin-top: 0.5rem;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 8px;
+    padding: 12px;
+    margin-top: 10px;
     display: flex;
-    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+    box-shadow: 0 1px 0 rgba(0, 0, 0, 0.15);
 }
 
 .switch {
@@ -12,26 +15,43 @@
 }
 
 .info {
-    align-self: flex-start;
+    flex: 1;
+    min-width: 0;
 }
 
 .eyebrow {
     margin-bottom: 0px !important;
     color: var(--text-strong);
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .btn {
-    border: none;
-    background: none;
+    border: 1px solid transparent;
+    background: transparent;
     color: var(--interactive-text-active);
 
-    transition: opacity 250ms;
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    transition: background-color 150ms, color 150ms, border-color 150ms;
 
     &:hover {
         color: var(--interactive-text-hover);
+        background: var(--background-modifier-hover);
     }
 }
 
 .btnContainer {
-    justify-content: flex-end;
+    display: flex;
+    align-items: center;
+}
+
+.card:hover {
+    background: rgba(255, 255, 255, 0.05);
+    border-color: rgba(255, 255, 255, 0.18);
 }

--- a/src/shelter/settings/components/KeybindMaker.module.css
+++ b/src/shelter/settings/components/KeybindMaker.module.css
@@ -1,15 +1,14 @@
 .grabBox {
-    position: relative;
-    flex-direction: row;
-    flex: 1;
     display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
 }
 .recBtn {
-    position: absolute;
+    flex: 0 0 auto;
     width: auto;
-    top: 50%;
-    right: 0;
-    transform: translate(-7px, -50%);
+    white-space: nowrap;
 }
 .error {
     color: var(--control-critical-secondary-text-default);

--- a/src/shelter/settings/components/KeybindMaker.tsx
+++ b/src/shelter/settings/components/KeybindMaker.tsx
@@ -105,7 +105,9 @@ export const KeybindMaker = (props: { close: () => void }) => {
                     </Show>
                 </span>
                 <div class={classes.grabBox}>
-                    <TextBox disabled value={accelerator()} onInput={setAccelerator} />
+                    <div style={{ flex: "1", "min-width": "0" }}>
+                        <TextBox disabled value={accelerator()} onInput={setAccelerator} />
+                    </div>
                     {recording() ? (
                         <Button
                             class={classes.recBtn}

--- a/src/shelter/settings/pages/KeybindsPage.tsx
+++ b/src/shelter/settings/pages/KeybindsPage.tsx
@@ -14,9 +14,11 @@ export function KeybindsPage() {
         <>
             <Header tag={HeaderTags.H1}>Keybinds</Header>
             <Divider mt mb />
-            <Button size={ButtonSizes.MAX} onClick={addNewKeybind}>
-                Create a keybind
-            </Button>
+            <div style={{ display: "flex", "justify-content": "flex-end", "margin-bottom": "12px" }}>
+                <Button size={ButtonSizes.LARGE} onClick={addNewKeybind}>
+                    Create a keybind
+                </Button>
+            </div>
             <For each={store.settings.keybinds}>{(keybind: Keybind) => <KeybindCard keybind={keybind} />}</For>
         </>
     );


### PR DESCRIPTION
## ✨ Overview
This PR improves the **Legcord Settings > Keybinds** section for a cleaner and more polished, “finished” design.

---

## 🔧 Changes

### Page: Keybinds
- The **Create a keybind** button is no longer full-width (better alignment and spacing)

### Modal: “Add keybind”
- Improved layout for the recording area (input + Record/Recording button) with a more stable structure

### Keybind cards
- Added a subtle background + thin but visible border to better distinguish each keybind  
- Refined alignment and delete action for improved visual consistency  

---

## 📁 Files changed
- `src/shelter/settings/pages/KeybindsPage.tsx`  
- `src/shelter/settings/components/KeybindMaker.tsx`  
- `src/shelter/settings/components/KeybindMaker.module.css`  
- `src/shelter/settings/components/KeybindCard.module.css`  

---

## 🧪 Testing

### ▶️ Run locally
```bash
pnpm start
```

Before :

<img width="1132" height="696" alt="image" src="https://github.com/user-attachments/assets/cc4dcb56-234b-4794-8077-f2c88f8d962e" />
<img width="810" height="458" alt="image" src="https://github.com/user-attachments/assets/d5507d5d-5b7b-472b-9f1f-f9e2c6f7c4e2" />


After : 

<img width="819" height="464" alt="image" src="https://github.com/user-attachments/assets/38228161-e3f5-497f-bd29-6feb1231e9bb" />
<img width="812" height="430" alt="image" src="https://github.com/user-attachments/assets/5a087e9e-57d5-4f08-9095-8c875284be89" />
