### PR TITLE
fix: dropdown height limit in Games settings

### DIFF
--- a/src/shelter/settings/components/Dropdown.module.css
+++ b/src/shelter/settings/components/Dropdown.module.css
@@ -48,24 +48,25 @@
     z-index: 100;
     overflow-y: auto;
     overflow-x: hidden;
-    
-    /* Discord-style scrollbar - no background */
-    scrollbar-width: none;
-    
+
+    /* Discord-style scrollbar - visible but no background */
+    scrollbar-width: thin;
+    scrollbar-color: rgba(255, 255, 255, 0.2) transparent;
+
     &::-webkit-scrollbar {
         width: 8px;
     }
-    
+
     &::-webkit-scrollbar-track {
         background: transparent;
     }
-    
+
     &::-webkit-scrollbar-thumb {
         background-color: rgba(255, 255, 255, 0.2);
         border-radius: 4px;
         border: none;
     }
-    
+
     &::-webkit-scrollbar-thumb:hover {
         background-color: rgba(255, 255, 255, 0.3);
     }

--- a/src/shelter/settings/components/Dropdown.module.css
+++ b/src/shelter/settings/components/Dropdown.module.css
@@ -48,28 +48,26 @@
     z-index: 100;
     overflow-y: auto;
     overflow-x: hidden;
-
-    /* Discord-style scrollbar */
-    scrollbar-width: thin;
-    scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
-
+    
+    /* Discord-style scrollbar - no background */
+    scrollbar-width: none;
+    
     &::-webkit-scrollbar {
         width: 8px;
     }
-
+    
     &::-webkit-scrollbar-track {
         background: transparent;
     }
-
+    
     &::-webkit-scrollbar-thumb {
-        background-color: var(--scrollbar-thumb);
+        background-color: rgba(255, 255, 255, 0.2);
         border-radius: 4px;
-        border: 2px solid transparent;
-        background-clip: content-box;
+        border: none;
     }
-
+    
     &::-webkit-scrollbar-thumb:hover {
-        background-color: var(--scrollbar-thumb-hover);
+        background-color: rgba(255, 255, 255, 0.3);
     }
 }
 option {

--- a/src/shelter/settings/components/Dropdown.module.css
+++ b/src/shelter/settings/components/Dropdown.module.css
@@ -47,6 +47,30 @@
     width: 100%;
     z-index: 100;
     overflow-y: auto;
+    overflow-x: hidden;
+
+    /* Discord-style scrollbar */
+    scrollbar-width: thin;
+    scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+
+    &::-webkit-scrollbar {
+        width: 8px;
+    }
+
+    &::-webkit-scrollbar-track {
+        background: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background-color: var(--scrollbar-thumb);
+        border-radius: 4px;
+        border: 2px solid transparent;
+        background-clip: content-box;
+    }
+
+    &::-webkit-scrollbar-thumb:hover {
+        background-color: var(--scrollbar-thumb-hover);
+    }
 }
 option {
     color: var(--text-subtle);

--- a/src/shelter/settings/components/Dropdown.tsx
+++ b/src/shelter/settings/components/Dropdown.tsx
@@ -21,10 +21,7 @@ export const Dropdown = (props: {
     createEffect(() => {
         if (!open() || !props.limitHeight) return;
 
-        const rect = container?.parentElement?.getBoundingClientRect();
-        if (!rect) return;
-
-        setMaxHeight(`${rect.bottom - container!.getBoundingClientRect().bottom - 20}px`);
+        setMaxHeight("300px");
     });
 
     const text = createMemo(() => props.options.find((o) => o.value === props.value)?.label ?? props.value);

--- a/src/shelter/settings/pages/RegisteredGamesPage.tsx
+++ b/src/shelter/settings/pages/RegisteredGamesPage.tsx
@@ -90,6 +90,7 @@ export function RegisteredGamesPage() {
             <div class={classes.addBox}>
                 <Dropdown
                     class={classes.dropdown}
+                    limitHeight={true}
                     value={selectedDetectable()}
                     onChange={(v) => {
                         if (v === "refresh") {


### PR DESCRIPTION
- Add limitHeight prop to Dropdown in RegisteredGamesPage
- Set fixed maxHeight of 300px for better UX with long lists
- Prevents dropdown from extending beyond screen height

Before : 

<img width="918" height="804" alt="image" src="https://github.com/user-attachments/assets/a3c0f190-66ba-470f-a829-6bea323ecee7" />


After : 

<img width="817" height="642" alt="image" src="https://github.com/user-attachments/assets/d0c29f46-945e-4df8-85b7-a2693c66b5ed" />
