### PR TITLE
fix: camera/mic device switching not working

### DIFF
--- a/electron-builder.ts
+++ b/electron-builder.ts
@@ -18,6 +18,7 @@ export const config: Configuration = {
         extendInfo: {
             NSMicrophoneUsageDescription: "Legcord requires access to the microphone to function properly.",
             NSCameraUsageDescription: "Legcord requires access to the camera to function properly.",
+            NSCameraUseContinuityCameraDeviceType: true,
             "com.apple.security.device.audio-input": true,
             "com.apple.security.device.camera": true,
         },

--- a/src/discord/preload/patches.mts
+++ b/src/discord/preload/patches.mts
@@ -29,6 +29,83 @@ const version = ipcRenderer.sendSync("displayVersion") as string;
     }
 }
 
+// Fix: Chromium on macOS ignores video deviceId when passed as an "ideal" constraint
+// (plain string), always returning the first camera. Discord passes deviceId this way.
+// This patch promotes "ideal" to "exact", stops active tracks before switching so macOS
+// releases the hardware, and falls back to the original behavior if "exact" fails.
+// Injected into the page context because contextIsolation is enabled.
+// See: https://github.com/electron/electron/issues/44502
+{
+    const cameraFixScript = document.createElement("script");
+    cameraFixScript.textContent = `(function() {
+    var _origGUM = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
+    var _activeVideoStreams = [];
+
+    function stopActiveVideoTracks() {
+        for (var i = 0; i < _activeVideoStreams.length; i++) {
+            var stream = _activeVideoStreams[i].deref();
+            if (stream) {
+                var tracks = stream.getVideoTracks();
+                for (var j = 0; j < tracks.length; j++) {
+                    tracks[j].stop();
+                }
+            }
+        }
+        _activeVideoStreams = [];
+    }
+
+    navigator.mediaDevices.getUserMedia = async function(constraints) {
+        if (!constraints || !constraints.video || typeof constraints.video === "boolean" ||
+            !constraints.video.deviceId || typeof constraints.video.deviceId !== "string") {
+            return _origGUM(constraints);
+        }
+
+        var requestedId = constraints.video.deviceId;
+
+        // Stop existing video tracks so macOS releases the camera hardware
+        stopActiveVideoTracks();
+        await new Promise(function(r) { setTimeout(r, 300); });
+
+        // Promote "ideal" (plain string) to "exact" to force device selection
+        var modified = Object.assign({}, constraints);
+        modified.video = Object.assign({}, constraints.video, {
+            deviceId: { exact: requestedId }
+        });
+
+        var stream;
+        try {
+            stream = await _origGUM(modified);
+        } catch(e) {
+            if (e.name === "OverconstrainedError") {
+                // exact failed — fall back to original ideal constraint
+                console.warn("[Legcord] Exact deviceId failed, falling back to ideal:", e.message);
+                stream = await _origGUM(constraints);
+            } else {
+                throw e;
+            }
+        }
+
+        if (stream.getVideoTracks().length > 0) {
+            _activeVideoStreams.push(new WeakRef(stream));
+        }
+        return stream;
+    };
+    console.log("[Legcord] Camera device selection fix applied");
+})();`;
+
+    if (document.documentElement) {
+        document.documentElement.prepend(cameraFixScript);
+    } else {
+        const fixObserver = new MutationObserver(() => {
+            if (document.documentElement) {
+                fixObserver.disconnect();
+                document.documentElement.prepend(cameraFixScript);
+            }
+        });
+        fixObserver.observe(document, { childList: true });
+    }
+}
+
 export async function getVirtmic() {
     try {
         const devices = await navigator.mediaDevices.enumerateDevices();

--- a/src/discord/preload/patches.mts
+++ b/src/discord/preload/patches.mts
@@ -64,7 +64,6 @@ const version = ipcRenderer.sendSync("displayVersion") as string;
 
         // Stop existing video tracks so macOS releases the camera hardware
         stopActiveVideoTracks();
-        await new Promise(function(r) { setTimeout(r, 300); });
 
         // Promote "ideal" (plain string) to "exact" to force device selection
         var modified = Object.assign({}, constraints);
@@ -72,23 +71,42 @@ const version = ipcRenderer.sendSync("displayVersion") as string;
             deviceId: { exact: requestedId }
         });
 
-        var stream;
-        try {
-            stream = await _origGUM(modified);
-        } catch(e) {
-            if (e.name === "OverconstrainedError") {
-                // exact failed — fall back to original ideal constraint
-                console.warn("[Legcord] Exact deviceId failed, falling back to ideal:", e.message);
-                stream = await _origGUM(constraints);
-            } else {
-                throw e;
+        // Retry with exponential backoff — first attempt is immediate, subsequent
+        // attempts double the delay (50, 100, 200, 400...) until the camera is released.
+        var MAX_RETRIES = 5;
+        var lastErr;
+        var delay = 50;
+        for (var i = 0; i < MAX_RETRIES; i++) {
+            if (i > 0) {
+                await new Promise(function(r) { setTimeout(r, delay); });
+                delay *= 2;
+            }
+            try {
+                var stream = await _origGUM(modified);
+                if (stream.getVideoTracks().length > 0) {
+                    _activeVideoStreams.push(new WeakRef(stream));
+                }
+                return stream;
+            } catch(e) {
+                lastErr = e;
+                if (e.name === "NotReadableError") {
+                    // Camera hardware still held — retry after next delay
+                    continue;
+                }
+                // OverconstrainedError or other — stop retrying
+                break;
             }
         }
 
-        if (stream.getVideoTracks().length > 0) {
-            _activeVideoStreams.push(new WeakRef(stream));
+        // All retries exhausted or non-retryable error — fall back to original ideal constraint
+        if (lastErr) {
+            console.warn("[Legcord] Exact deviceId failed, falling back to ideal:", lastErr.name, lastErr.message);
         }
-        return stream;
+        var fallbackStream = await _origGUM(constraints);
+        if (fallbackStream.getVideoTracks().length > 0) {
+            _activeVideoStreams.push(new WeakRef(fallbackStream));
+        }
+        return fallbackStream;
     };
     console.log("[Legcord] Camera device selection fix applied");
 })();`;

--- a/src/discord/preload/patches.mts
+++ b/src/discord/preload/patches.mts
@@ -40,39 +40,51 @@ const version = ipcRenderer.sendSync("displayVersion") as string;
     cameraFixScript.textContent = `(function() {
     var _origGUM = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
     var _activeVideoStreams = [];
+    var _activeAudioStreams = [];
 
-    function stopActiveVideoTracks() {
-        for (var i = 0; i < _activeVideoStreams.length; i++) {
-            var stream = _activeVideoStreams[i].deref();
+    function stopTrackedStreams(list, kind) {
+        for (var i = 0; i < list.length; i++) {
+            var stream = list[i].deref();
             if (stream) {
-                var tracks = stream.getVideoTracks();
+                var tracks = kind === "video" ? stream.getVideoTracks() : stream.getAudioTracks();
                 for (var j = 0; j < tracks.length; j++) {
-                    tracks[j].stop();
+                    if (tracks[j].readyState === "live") tracks[j].stop();
                 }
             }
         }
-        _activeVideoStreams = [];
+        list.length = 0;
+    }
+
+    function trackStream(stream) {
+        var ref = new WeakRef(stream);
+        if (stream.getVideoTracks().length > 0) _activeVideoStreams.push(ref);
+        if (stream.getAudioTracks().length > 0) _activeAudioStreams.push(ref);
     }
 
     navigator.mediaDevices.getUserMedia = async function(constraints) {
-        if (!constraints || !constraints.video || typeof constraints.video === "boolean" ||
-            !constraints.video.deviceId || typeof constraints.video.deviceId !== "string") {
-            return _origGUM(constraints);
+        var hasVideo = constraints && constraints.video && typeof constraints.video !== "boolean";
+        var hasAudio = constraints && constraints.audio && typeof constraints.audio !== "boolean";
+
+        // Release previous hardware when new request comes in for the same kind
+        if (hasVideo && _activeVideoStreams.length > 0) stopTrackedStreams(_activeVideoStreams, "video");
+        if (hasAudio && _activeAudioStreams.length > 0) stopTrackedStreams(_activeAudioStreams, "audio");
+
+        var hasStringVideoDeviceId = hasVideo && typeof constraints.video.deviceId === "string";
+        if (!hasStringVideoDeviceId) {
+            var stream = await _origGUM(constraints);
+            trackStream(stream);
+            return stream;
         }
 
+        // Promote video "ideal" (plain string) to "exact" to force device selection
         var requestedId = constraints.video.deviceId;
-
-        // Stop existing video tracks so macOS releases the camera hardware
-        stopActiveVideoTracks();
-
-        // Promote "ideal" (plain string) to "exact" to force device selection
         var modified = Object.assign({}, constraints);
         modified.video = Object.assign({}, constraints.video, {
             deviceId: { exact: requestedId }
         });
 
         // Retry with exponential backoff — first attempt is immediate, subsequent
-        // attempts double the delay (50, 100, 200, 400...) until the camera is released.
+        // attempts double the delay (50, 100, 200, 400...) until the device is released.
         var MAX_RETRIES = 5;
         var lastErr;
         var delay = 50;
@@ -83,17 +95,11 @@ const version = ipcRenderer.sendSync("displayVersion") as string;
             }
             try {
                 var stream = await _origGUM(modified);
-                if (stream.getVideoTracks().length > 0) {
-                    _activeVideoStreams.push(new WeakRef(stream));
-                }
+                trackStream(stream);
                 return stream;
             } catch(e) {
                 lastErr = e;
-                if (e.name === "NotReadableError") {
-                    // Camera hardware still held — retry after next delay
-                    continue;
-                }
-                // OverconstrainedError or other — stop retrying
+                if (e.name === "NotReadableError") continue;
                 break;
             }
         }
@@ -103,12 +109,9 @@ const version = ipcRenderer.sendSync("displayVersion") as string;
             console.warn("[Legcord] Exact deviceId failed, falling back to ideal:", lastErr.name, lastErr.message);
         }
         var fallbackStream = await _origGUM(constraints);
-        if (fallbackStream.getVideoTracks().length > 0) {
-            _activeVideoStreams.push(new WeakRef(fallbackStream));
-        }
+        trackStream(fallbackStream);
         return fallbackStream;
     };
-    console.log("[Legcord] Camera device selection fix applied");
 })();`;
 
     if (document.documentElement) {


### PR DESCRIPTION
Resolves #1040

Chromium [changed how it handles "ideal" `deviceId` constraints](https://groups.google.com/a/chromium.org/g/blink-dev/c/El5jaGnhVu4) starting around Chrome 130 — it now ignores them and returns whatever device it considers "preferred" (usually the first one). Discord passes `deviceId` as a plain string (ideal constraint), so camera/mic switching silently does nothing. Discord's own desktop app is unaffected because it uses a native media engine that bypasses Chromium's `getUserMedia`.

| Electron | Chromium | Affected? |
|----------|----------|-----------|
| 39 | ~128 | No |
| 40 | ~130 | Partially (Finch rollout) |
| 41 | ~132 | Yes |

This PR works around it by:
- Promoting ideal `deviceId` to `{ exact: deviceId }` in a page-context `getUserMedia` wrapper
- Stopping stale audio/video tracks before acquiring new ones so the OS releases the hardware
- Retrying with exponential backoff if the device isn't released yet
- Falling back to the original behavior if `exact` throws `OverconstrainedError`
- Adding `NSCameraUseContinuityCameraDeviceType` to Info.plist for macOS Continuity Camera support

This is a workaround until Chromium fixes device selection upstream:
- https://github.com/electron/electron/issues/44502

Tested on macOS, Linux, and Windows. The bug is still present on v1.2.2 (latest release).