### PR TITLE
fix: dropdown max height calculation

### DIFF
--- a/src/shelter/settings/components/Dropdown.tsx
+++ b/src/shelter/settings/components/Dropdown.tsx
@@ -7,10 +7,11 @@ export const Dropdown = (props: {
     options: { label: string; value: string | number }[];
     styles?: { [key: string]: string };
     limitHeight?: boolean | undefined;
+    maxHeight?: number;
     class?: string;
 }) => {
     const [open, set] = createSignal(false);
-    const [maxHeight, setMaxHeight] = createSignal("");
+    const [maxHeight, setMaxHeight] = createSignal(`${props.maxHeight}px`);
     let container: HTMLDivElement | undefined;
 
     const handler = (e: MouseEvent) => !container?.contains(e.target as Node) && set(false);
@@ -19,9 +20,13 @@ export const Dropdown = (props: {
     onCleanup(() => document.removeEventListener("click", handler));
 
     createEffect(() => {
-        if (!open() || !props.limitHeight) return;
+        if (!open() || !props.limitHeight || props.maxHeight) return;
 
-        setMaxHeight("300px");
+        const rect = container?.parentElement?.getBoundingClientRect();
+        if (!rect) return;
+
+        const availableSpace = rect.bottom - container!.getBoundingClientRect().bottom - 20;
+        setMaxHeight(`${availableSpace}px`);
     });
 
     const text = createMemo(() => props.options.find((o) => o.value === props.value)?.label ?? props.value);

--- a/src/shelter/settings/pages/RegisteredGamesPage.tsx
+++ b/src/shelter/settings/pages/RegisteredGamesPage.tsx
@@ -90,7 +90,8 @@ export function RegisteredGamesPage() {
             <div class={classes.addBox}>
                 <Dropdown
                     class={classes.dropdown}
-                    limitHeight={true}
+                    limitHeight
+                    maxHeight={300}
                     value={selectedDetectable()}
                     onChange={(v) => {
                         if (v === "refresh") {


### PR DESCRIPTION
the code was there to limit the drop down's height to the container's available height, setting it to a fixed value breaks the keybind action drop down since it expands past the container's available height making the container scrollable instead of the drop down

before:
<img width="580" height="483" alt="image" src="https://github.com/user-attachments/assets/93a9c76a-cc19-4a78-bba3-4b26dafae1f1" />

after:
<img width="556" height="362" alt="image" src="https://github.com/user-attachments/assets/0afb7487-8036-40cc-bb85-ce61d007837e" />