### PR TITLE
fix: allow shelter plugins hosted on spikehd.dev to check for updates…

### DIFF
--- a/src/discord/extensions/csp.ts
+++ b/src/discord/extensions/csp.ts
@@ -7,7 +7,7 @@ const LEGCORD_CSP = [
     "style-src 'self' 'unsafe-inline' https://*.discord.com https://discord.com https://fonts.googleapis.com",
     "img-src 'self' blob: data: https://*.discord.com https://discord.com https://*.discordapp.com https://cdn.discordapp.com https://*.githubusercontent.com https://*.github.com https://raw.githubusercontent.com",
     "font-src 'self' data: https://fonts.gstatic.com",
-    "connect-src 'self' blob: https://*.discord.com https://discord.com wss://*.discord.com wss://gateway.discord.gg https://*.githubusercontent.com https://*.github.com https://api.github.com",
+    "connect-src 'self' blob: https://*.discord.com https://discord.com wss://*.discord.com wss://gateway.discord.gg https://*.githubusercontent.com https://*.github.com https://api.github.com https://*.spikehd.dev https://spikehd.dev",
     "media-src 'self' blob: https://*.discord.com https://discord.com",
     "worker-src 'self' blob:",
     "frame-src 'self' https://*.discord.com https://discord.com https://*.youtube.com https://youtube.com https://*.twitch.tv https://open.spotify.com",


### PR DESCRIPTION
### Root Cause
The strict CSP policy's `connect-src` directive only allowed connections to:
- `discord.com`
- `githubusercontent.com`  
- `github.com`
- `api.github.com`

Third-party shelter plugin repositories like `spikehd.dev` were blocked.

### Solution
Added `https://*.spikehd.dev` and `https://spikehd.dev` to the `connect-src` directive in the strict CSP policy.

### Files Changed
- [src/discord/extensions/csp.ts](cci:7://file:///c:/Users/sionukk/Desktop/Leg/legcord/src/discord/extensions/csp.ts:0:0-0:0) - Added spikehd.dev domains to connect-src

### Testing
- [x] Lint passes (`pnpm run lint`)
- [x] Plugin updates now work in Strict CSP mode
- [x] No security regression (specific domain added, not wildcard `*`)

### Notes
This fix only affects users who have **Strict CSP** enabled. Users with "None" or "Vanilla" CSP settings were not affected by this issue.