### PR TITLE
fix: open settings from tray/menu by clicking the settings button dir…

### DIFF
--- a/src/discord/menu.ts
+++ b/src/discord/menu.ts
@@ -53,16 +53,9 @@ export function setMenu(): void {
                     click() {
                         mainWindows.forEach((mainWindow) => {
                             mainWindow.show();
-                            void mainWindow.webContents.executeJavaScript(`window.shelter.flux.dispatcher.dispatch({
-                                "type": "USER_SETTINGS_MODAL_OPEN",
-                                "section": "legcord-settings",
-                                "subsection": null,
-                                "openWithoutBackstack": false
-                            })`);
                             void mainWindow.webContents.executeJavaScript(
-                                `window.shelter.flux.dispatcher.dispatch({type: "LAYER_PUSH", component: "USER_SETTINGS"})`,
+                                `window.shelter.flux.dispatcher.dispatch({type: "USER_SETTINGS_MODAL_OPEN"})`,
                             );
-                            // this opens the legcord tab directly in the settings modal
                         });
                     },
                 },

--- a/src/discord/tray.ts
+++ b/src/discord/tray.ts
@@ -54,15 +54,11 @@ export function createTray() {
                 mainWindows.forEach((mainWindow) => {
                     mainWindow.show();
 
-                    void mainWindow.webContents.executeJavaScript(`window.shelter.flux.dispatcher.dispatch({
-                                "type": "USER_SETTINGS_MODAL_OPEN",
-                                "section": "My Account",
-                                "subsection": null,
-                                "openWithoutBackstack": false
-                            })`);
-                    void mainWindow.webContents.executeJavaScript(
-                        `window.shelter.flux.dispatcher.dispatch({type: "LAYER_PUSH", component: "USER_SETTINGS"})`,
-                    );
+                    mainWindow.webContents
+                        .executeJavaScript(
+                            `document.querySelector('[aria-label="User Settings"]')?.click()`,
+                        )
+                        .catch((e) => console.error("[legcord:tray] open settings error:", e));
                 });
             },
         },


### PR DESCRIPTION
fix:      The previous approach dispatched USER_SETTINGS_MODAL_OPEN and LAYER_PUSH
      through shelter's flux dispatcher. LAYER_PUSH with component "USER_SETTINGS"
      crashed with "CH[e] is not a function" because Discord's layer component
      registry doesn't have that component registered when the window is shown
      from a hidden state. USER_SETTINGS_MODAL_OPEN alone did nothing.

      Switching to a direct DOM click on the User Settings button mirrors exactly
      what the user does in-app and avoids coupling to Discord's internal
      dispatcher state.

## Problem

Crash on clicking settings

## Solution

Removed the shelter command

## Risk

Doesn't migrate to Legcord settings

## Testing

- [X] `pnpm lint`
- [X] `pnpm build` if this PR touches runtime, bundling, or packaging code
- [ ] Manual verification for affected flows
- [ ] Screenshots or recordings for UI changes