### PR TITLE
fix: injection-typeerror

### DIFF
--- a/src/discord/ipc.ts
+++ b/src/discord/ipc.ts
@@ -83,13 +83,11 @@ export function registerIpc(passedWindow: BrowserWindow): void {
     });
     ipcMain.handle("getCustomBundle", () => {
         const enabled = getConfig("mods").includes("custom");
-        if (enabled) {
-            return {
-                js: ifExistsRead(path.join(app.getPath("userData"), "custom.js")),
-                css: ifExistsRead(path.join(app.getPath("userData"), "custom.css")),
-                enabled,
-            };
-        }
+        return {
+            js: enabled ? ifExistsRead(path.join(app.getPath("userData"), "custom.js")) : undefined,
+            css: enabled ? ifExistsRead(path.join(app.getPath("userData"), "custom.css")) : undefined,
+            enabled,
+        };
     });
 
     // theming

--- a/src/discord/preload/mods/custom.mts
+++ b/src/discord/preload/mods/custom.mts
@@ -3,7 +3,7 @@ import type { ModBundle } from "../../../@types/ModBundle.js";
 async function inject() {
     try {
         await ipcRenderer.invoke("getCustomBundle").then(async (bundle: ModBundle) => {
-            if (bundle.enabled) {
+            if (bundle?.enabled) {
                 await webFrame.executeJavaScript(bundle.js);
                 if (bundle.css) {
                     webFrame.insertCSS(bundle.css); //NOTE - Custom mods might require CSS.

--- a/src/discord/preload/mods/equicord.mts
+++ b/src/discord/preload/mods/equicord.mts
@@ -3,7 +3,7 @@ import type { ModBundle } from "../../../@types/ModBundle.js";
 async function inject() {
     try {
         await ipcRenderer.invoke("getEquicordBundle").then(async (bundle: ModBundle) => {
-            if (bundle.enabled) {
+            if (bundle?.enabled) {
                 await webFrame.executeJavaScript(bundle.js);
                 webFrame.insertCSS(bundle.css!); //NOTE - Equicord requires CSS.
             }

--- a/src/discord/preload/mods/shelter.mts
+++ b/src/discord/preload/mods/shelter.mts
@@ -17,7 +17,7 @@ if (process.platform === "darwin") {
 async function inject() {
     try {
         await ipcRenderer.invoke("getShelterBundle").then(async (bundle: ModBundle) => {
-            if (bundle.enabled) {
+            if (bundle?.enabled) {
                 await webFrame.executeJavaScript(`(()=>{
                 const SHELTER_INJECTOR_PLUGINS = ${JSON.stringify(requiredPlugins)};
                 ${bundle.js}

--- a/src/discord/preload/mods/vencord.mts
+++ b/src/discord/preload/mods/vencord.mts
@@ -3,7 +3,7 @@ import type { ModBundle } from "../../../@types/ModBundle.js";
 async function inject() {
     try {
         await ipcRenderer.invoke("getVencordBundle").then(async (bundle: ModBundle) => {
-            if (bundle.enabled) {
+            if (bundle?.enabled) {
                 await webFrame.executeJavaScript(bundle.js);
                 webFrame.insertCSS(bundle.css!); //NOTE - Vencord requires CSS.
             }


### PR DESCRIPTION
  Problem
  A TypeError: Cannot read properties of undefined (reading 'enabled') was occurring during the mod injection process. This was primarily caused by the
  getCustomBundle IPC handler returning undefined when the "custom" mod was disabled in the settings. Consequently, the preload script's promise resolution
  attempted to access the .enabled property on a nullish value, crashing the injection pipeline.

  Solution
   - IPC Handler Fix: Updated src/discord/ipc.ts to ensure that getCustomBundle always returns a ModBundle object (including the enabled boolean), even if the mod is disabled. This brings it into alignment with the behavior of other mod handlers like Vencord and Equicord.
   - Defensive Hardening: Updated all mod injection scripts (src/discord/preload/mods/ for custom, equicord, shelter, and vencord) to use optional chaining (bundle?.enabled). This provides a secondary layer of defense to prevent crashes if IPC responses are ever malformed or missing.

  Risk
  Very low. The changes are focused on improving the robustness of the injection pipeline and ensuring type consistency in IPC communication. No configuration
  schemas or public APIs were changed.

  Validation
   - Linting: pnpm lint was run. While the project has pre-existing lint issues in unrelated files, the modified files are correct and follow the project's formatting.
   - Build: Verified that the project compiles and that the ModBundle type interface is strictly respected.
   - Manual Verification: Confirmed that disabling the custom mod no longer triggers a TypeError in the injection script.
   - Platform Coverage: Verified on Windows. Since these changes affect shared Electron IPC and preload logic, they are cross-platform by nature.

## Summary

<!-- Briefly describe what this PR changes. -->

## Problem

<!-- What issue, bug, feature request, or maintenance task does this address? -->

## Solution

<!-- What changed, and why is this the right approach? -->

## Risk

<!-- Call out anything that could regress, be platform-specific, or require extra review. -->

## Testing

<!-- Describe the checks you ran and any manual smoke tests. -->

- [X] `pnpm lint`
- [X] `pnpm build` if this PR touches runtime, bundling, or packaging code
- [x] Manual verification for affected flows
- [ ] Screenshots or recordings for UI changes

## Notes

<!-- Add links to related issues, screenshots, follow-up work, or implementation details. -->
