### PR TITLE
fix: Windows mic drop in getUserMedia patch

### DIFF
--- a/src/discord/preload/patches.mts
+++ b/src/discord/preload/patches.mts
@@ -35,9 +35,13 @@ const version = ipcRenderer.sendSync("displayVersion") as string;
 // releases the hardware, and falls back to the original behavior if "exact" fails.
 // Injected into the page context because contextIsolation is enabled.
 // See: https://github.com/electron/electron/issues/44502
+// Stopping prior audio streams on every new getUserMedia breaks Discord on Windows/Linux
+// (multiple object-shaped audio requests); keep that behavior only on darwin.
 {
+    const stopPrevAudioStreams = process.platform === "darwin";
     const cameraFixScript = document.createElement("script");
     cameraFixScript.textContent = `(function() {
+    var legcordStopPrevAudioStreams = ${stopPrevAudioStreams};
     var _origGUM = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
     var _activeVideoStreams = [];
     var _activeAudioStreams = [];
@@ -58,16 +62,16 @@ const version = ipcRenderer.sendSync("displayVersion") as string;
     function trackStream(stream) {
         var ref = new WeakRef(stream);
         if (stream.getVideoTracks().length > 0) _activeVideoStreams.push(ref);
-        if (stream.getAudioTracks().length > 0) _activeAudioStreams.push(ref);
+        if (legcordStopPrevAudioStreams && stream.getAudioTracks().length > 0) _activeAudioStreams.push(ref);
     }
 
     navigator.mediaDevices.getUserMedia = async function(constraints) {
         var hasVideo = constraints && constraints.video && typeof constraints.video !== "boolean";
         var hasAudio = constraints && constraints.audio && typeof constraints.audio !== "boolean";
 
-        // Release previous hardware when new request comes in for the same kind
+        // Release previous hardware when new request comes in for the same kind (audio: darwin only)
         if (hasVideo && _activeVideoStreams.length > 0) stopTrackedStreams(_activeVideoStreams, "video");
-        if (hasAudio && _activeAudioStreams.length > 0) stopTrackedStreams(_activeAudioStreams, "audio");
+        if (legcordStopPrevAudioStreams && hasAudio && _activeAudioStreams.length > 0) stopTrackedStreams(_activeAudioStreams, "audio");
 
         var hasStringVideoDeviceId = hasVideo && typeof constraints.video.deviceId === "string";
         if (!hasStringVideoDeviceId) {


### PR DESCRIPTION
The camera-fix wrapper stopped all tracked audio tracks on every new getUserMedia call with object-shaped audio constraints. On Windows and Linux, Discord often opens a second stream (level meter, processing), which ended the voice WebRTC stream while the OS microphone still worked.

## Summary

Limit prior-audio teardown in the preload `getUserMedia` camera-fix to macOS only, so Windows and Linux can keep multiple object-shaped audio streams (voice, meter, processing) without Legcord stopping the active voice track.

## Problem

The camera-fix wrapper stopped all tracked audio tracks on every new `getUserMedia` call with object-shaped `audio` constraints. On Windows and Linux, Discord often opens a second stream (level meter, processing), which ended the voice WebRTC stream while the OS microphone still worked.

Users reported the mic working only for a few seconds after launch (e.g. in **User Settings → Voice & Video**), while official Discord on the same machine behaved normally. The patch was originally aimed at macOS camera `deviceId` handling ([Electron #44502](https://github.com/electron/electron/issues/44502)), but the audio teardown ran on all platforms.

## Solution

Stop and track prior audio streams only on `darwin`. Video `deviceId` handling is unchanged.

Changes in [`src/discord/preload/patches.mts`](src/discord/preload/patches.mts):

- Inject `legcordStopPrevAudioStreams` from preload (`process.platform === "darwin"`) into the page-context script.
- Gate `stopTrackedStreams(..., "audio")` and `_activeAudioStreams` tracking behind that flag.
- Leave `_activeVideoStreams` teardown and video `deviceId` “ideal” → `exact` promotion as-is.

## Risk

- **macOS:** Prior-audio stop behavior is unchanged; quick smoke on camera switch / voice is still worthwhile.
- **Windows/Linux:** Legcord no longer stops older audio streams on new `getUserMedia` calls — intended fix; unlikely to affect normal Discord usage.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm build` if this PR touches runtime, bundling, or packaging code
- [x] Manual verification for affected flows — Windows: `pnpm start`, mic test in settings stays responsive >1 min; voice channel + speaking indicator (reporter)
- [ ] Screenshots or recordings for UI changes (N/A — no UI change)

## Notes

Narrow scope: audio teardown gating only. Does not change `getDisplayMedia` / venmic, deferred 5s preload injections, or other preload behavior.

Related symptom: mic appears dead in-app while OS “listen to this device” still shows signal.