### PR TITLE
feat(screenshare): implement macOS native system audio loopback capture

### DIFF
--- a/electron-builder.ts
+++ b/electron-builder.ts
@@ -18,6 +18,8 @@ export const config: Configuration = {
         extendInfo: {
             NSMicrophoneUsageDescription: "Legcord requires access to the microphone to function properly.",
             NSCameraUsageDescription: "Legcord requires access to the camera to function properly.",
+            NSAudioCaptureUsageDescription:
+                "Legcord requires access to system audio to share sound during screenshare.",
             NSCameraUseContinuityCameraDeviceType: true,
             "com.apple.security.device.audio-input": true,
             "com.apple.security.device.camera": true,

--- a/src/discord/screenshare.ts
+++ b/src/discord/screenshare.ts
@@ -17,6 +17,7 @@ export function registerCustomHandler(): void {
                 console.log("WebRTC Capturer detected, using native window picker.");
                 if (sources[0] === undefined) return callback({});
             }
+            ipcMain.removeAllListeners("startScreenshare");
             ipcMain.once("startScreenshare", (_event, id: string, name: string, audio: boolean) => {
                 console.log(`ID: ${id}`);
                 if (id === "none") {
@@ -31,6 +32,7 @@ export function registerCustomHandler(): void {
                     switch (process.platform) {
                         case "win32":
                         case "linux":
+                        case "darwin":
                             options = { video: result };
                             if (audio)
                                 options = {
@@ -48,6 +50,6 @@ export function registerCustomHandler(): void {
                 window.webContents.send("getSources", sources);
             });
         },
-        { useSystemPicker: getConfig("useMacSystemPicker") },
+        { useSystemPicker: false },
     );
 }

--- a/src/discord/screenshare.ts
+++ b/src/discord/screenshare.ts
@@ -50,6 +50,6 @@ export function registerCustomHandler(): void {
                 window.webContents.send("getSources", sources);
             });
         },
-        { useSystemPicker: false },
+        { useSystemPicker: getConfig("useMacSystemPicker") },
     );
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -159,6 +159,9 @@ if (!app.requestSingleInstanceLock() && getConfig("multiInstance") === false) {
     if (process.platform === "darwin") {
         const status = systemPreferences.getMediaAccessStatus("screen");
         console.log(`macOS screenshare permission: ${status}`);
+        enableFeatures.add("MacLoopbackAudioForScreenShare");
+        enableFeatures.add("MacSckSystemAudioLoopbackOverride");
+        enableFeatures.add("MacCatapSystemAudioLoopbackCapture");
     }
     // work around chrome 66 disabling autoplay by default
     app.commandLine.appendSwitch("autoplay-policy", "no-user-gesture-required");

--- a/src/shelter/screenshare/components/ScreensharePicker.tsx
+++ b/src/shelter/screenshare/components/ScreensharePicker.tsx
@@ -32,8 +32,9 @@ async function getVirtmic() {
 }
 
 const original = navigator.mediaDevices.getDisplayMedia;
-export async function patchNavigator() {
-    navigator.mediaDevices.getDisplayMedia = async function (opts) {
+export async function patchNavigator(requestAudio = false) {
+    navigator.mediaDevices.getDisplayMedia = async function (opts = {}) {
+        if (requestAudio) opts.audio = true;
         const stream = await original.call(this, opts);
         const video = stream.getVideoTracks()[0];
 
@@ -46,16 +47,20 @@ export async function patchNavigator() {
             height: height,
         };
 
-        video
-            .applyConstraints(stream_constraints)
-            .then(() => console.info("Applied video stream track settings.", stream_constraints))
-            .catch(() => {
-                console.error("Failed to apply video stream track settings.", stream_constraints);
-            });
+        if (video) {
+            video
+                .applyConstraints(stream_constraints)
+                .then(() => {
+                    console.log(`Stream modified -> (${width}x${height}) ${store.fps}FPS`);
+                })
+                .catch((error) => {
+                    console.error("Failed to apply video constraints:", error);
+                });
+        }
 
         const virtmic_id = await getVirtmic();
-        stream.getAudioTracks().forEach((t) => stream.removeTrack(t));
         if (virtmic_id) {
+            stream.getAudioTracks().forEach((t) => stream.removeTrack(t));
             const audio = await navigator.mediaDevices.getUserMedia({
                 audio: {
                     deviceId: {
@@ -94,7 +99,7 @@ export const ScreensharePicker = (props: {
             showToast(t["screenshare-selectSource"], "error");
         }
 
-        patchNavigator();
+        patchNavigator(audio());
 
         window.legcord.screenshare.start(source(), name(), audio());
 
@@ -177,31 +182,29 @@ export const ScreensharePicker = (props: {
                             />
                         </div>
                     </div>
-                    <Show when={window.legcord.platform !== "darwin"}>
-                        <div class={classes.audioRow} style="margin-top: 12px;">
-                            <div class={classes.audioLabel}>
-                                <svg class={classes.audioIcon} viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                                    <title>Audio</title>
-                                    <path
-                                        d="M11 5L6 9H2v6h4l5 4V5z"
-                                        stroke="currentColor"
-                                        stroke-width="2"
-                                        stroke-linecap="round"
-                                        stroke-linejoin="round"
-                                    />
-                                    <path
-                                        d="M19.07 4.93a10 10 0 010 14.14M15.54 8.46a5 5 0 010 7.07"
-                                        stroke="currentColor"
-                                        stroke-width="2"
-                                        stroke-linecap="round"
-                                        stroke-linejoin="round"
-                                    />
-                                </svg>
-                                Share Audio
-                            </div>
-                            <Checkbox checked={audio()} onChange={setAudio} />
+                    <div class={classes.audioRow} style="margin-top: 12px;">
+                        <div class={classes.audioLabel}>
+                            <svg class={classes.audioIcon} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                                <title>Audio</title>
+                                <path
+                                    d="M11 5L6 9H2v6h4l5 4V5z"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                />
+                                <path
+                                    d="M19.07 4.93a10 10 0 010 14.14M15.54 8.46a5 5 0 010 7.07"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                />
+                            </svg>
+                            Share Audio
                         </div>
-                    </Show>
+                        <Checkbox checked={audio()} onChange={setAudio} />
+                    </div>
 
                     <Show when={window.legcord.platform === "linux" && props.audioSources !== undefined && audio()}>
                         <Divider mt mb />


### PR DESCRIPTION
This PR enables macOS 13+ ScreenCaptureKit audio loopback functionality by:
- Injecting required Chromium feature flags
- Adding `NSAudioCaptureUsageDescription` entitlement
- Forcing `useSystemPicker=false` to preserve custom UI loopback hooks
- Injecting `opts.audio=true` into intercepted `getDisplayMedia` requests
- Patching multiple `ipcMain` listener leak in the screenshare process