### PR TITLE
fix: first launch blank settings and theme

### DIFF
--- a/src/shelter/settings/index.ts
+++ b/src/shelter/settings/index.ts
@@ -22,26 +22,30 @@ const {
     flux: { dispatcher, storesFlat },
 } = shelter;
 
-const settingsPages = [
-    registerSection("divider"),
-    registerSection("header", "Legcord"),
-    registerSection("section", "legcord-settings", "Settings", SettingsPage, { icon: SettingsSidebarIcon }),
-    registerSection("section", "legcord-themes", "Themes", ThemesPage, { icon: ThemesSidebarIcon }),
-    registerSection("section", "legcord-plugins", "Plugins", PluginsPage, { icon: PluginsSidebarIcon }),
-    registerSection("section", "legcord-keybinds", "Keybinds", KeybindsPage, { icon: KeybindsSidebarIcon }),
-    registerSection("section", "legcord-games", "Games", RegisteredGamesPage, { icon: GamesSidebarIcon }),
-];
+let settingsCleanups: (() => void)[] = [];
+
+function registerSections(): (() => void)[] {
+    return [
+        registerSection("divider"),
+        registerSection("header", "Legcord"),
+        registerSection("section", "legcord-settings", "Settings", SettingsPage, { icon: SettingsSidebarIcon }),
+        registerSection("section", "legcord-themes", "Themes", ThemesPage, { icon: ThemesSidebarIcon }),
+        registerSection("section", "legcord-plugins", "Plugins", PluginsPage, { icon: PluginsSidebarIcon }),
+        registerSection("section", "legcord-keybinds", "Keybinds", KeybindsPage, { icon: KeybindsSidebarIcon }),
+        registerSection("section", "legcord-games", "Games", RegisteredGamesPage, { icon: GamesSidebarIcon }),
+    ];
+}
 
 function restartRequired(payload: { event: string; properties: { origin_pane: string } }) {
     if (payload.event === "settings_pane_viewed" && typeof payload.properties.origin_pane !== "undefined") {
         const pane = payload.properties.origin_pane;
         if ((pane === "legcord-settings" || pane === "legcord-games") && isRestartRequired) {
             openConfirmationModal({
-                header: () => store.i18n["settings-restartRequired"],
-                body: () => store.i18n["settings-restartRequiredBody"],
+                header: () => store.i18n?.["settings-restartRequired"] ?? "Restart required",
+                body: () => store.i18n?.["settings-restartRequiredBody"] ?? "A restart is required to apply changes.",
                 type: "danger",
-                confirmText: store.i18n["settings-restart"],
-                cancelText: store.i18n["settings-restartLater"],
+                confirmText: store.i18n?.["settings-restart"] ?? "Restart",
+                cancelText: store.i18n?.["settings-restartLater"] ?? "Later",
             }).then(
                 () => window.legcord.restart(),
                 () => console.log("restart skipped"),
@@ -57,11 +61,11 @@ export function onLoad() {
     store.i18n = window.legcord.translations;
     log("Legcord Settings");
     window.legcord.settings.setLang(storesFlat.LocaleStore.locale);
-    settingsPages;
+    settingsCleanups = registerSections();
     dispatcher.subscribe("TRACK", restartRequired);
 }
 export function onUnload() {
-    settingsPages.forEach((e) => {
+    settingsCleanups.forEach((e) => {
         e();
     });
     dispatcher.unsubscribe("TRACK", restartRequired);

--- a/src/shelter/settings/pages/SettingsPage.tsx
+++ b/src/shelter/settings/pages/SettingsPage.tsx
@@ -12,21 +12,24 @@ const {
     ui: { SwitchItem, Header, HeaderTags, Button, ButtonSizes },
 } = shelter;
 
-const settings = store.settings as Settings;
-const noBundleUpdates = () => {
+const noBundleUpdates = (settings: Settings) => {
     const value = settings.noBundleUpdates;
     if (Array.isArray(value)) return value;
     return value ? ["shelter", "vencord", "equicord", "custom"] : [];
 };
 
 export function SettingsPage() {
+    const settings = store.settings as Settings;
     if (!settings) {
         return (
             <>
                 <Header class={classes.category} tag={HeaderTags.HeadingXL}>
-                    {store.i18n["settings-firstTimeCrash"]}
+                    {store.i18n?.["settings-firstTimeCrash"] ?? "Setting things up..."}
                 </Header>
-                <p>{store.i18n["settings-firstTimeCrash-desc"]}</p>
+                <p>
+                    {store.i18n?.["settings-firstTimeCrash-desc"] ??
+                        "Settings are not available on a first-time launch. Please restart."}
+                </p>
                 <br />
                 <Button size={ButtonSizes.MAX} onClick={() => window.legcord.restart()}>
                     Restart Legcord
@@ -529,9 +532,9 @@ export function SettingsPage() {
             </Header>
             <SwitchItem
                 note={store.i18n["settings-noBundleUpdates-desc"]}
-                value={noBundleUpdates().includes("shelter")}
+                value={noBundleUpdates(settings).includes("shelter")}
                 onChange={(e: boolean) => {
-                    const next = new Set(noBundleUpdates());
+                    const next = new Set(noBundleUpdates(settings));
                     if (e) next.add("shelter");
                     else next.delete("shelter");
                     setConfig("noBundleUpdates", Array.from(next) as Settings["noBundleUpdates"], true);
@@ -541,9 +544,9 @@ export function SettingsPage() {
             </SwitchItem>
             <Show when={settings.mods.includes("vencord")}>
                 <SwitchItem
-                    value={noBundleUpdates().includes("vencord")}
+                    value={noBundleUpdates(settings).includes("vencord")}
                     onChange={(e: boolean) => {
-                        const next = new Set(noBundleUpdates());
+                        const next = new Set(noBundleUpdates(settings));
                         if (e) next.add("vencord");
                         else next.delete("vencord");
                         setConfig("noBundleUpdates", Array.from(next) as Settings["noBundleUpdates"], true);
@@ -554,9 +557,9 @@ export function SettingsPage() {
             </Show>
             <Show when={settings.mods.includes("equicord")}>
                 <SwitchItem
-                    value={noBundleUpdates().includes("equicord")}
+                    value={noBundleUpdates(settings).includes("equicord")}
                     onChange={(e: boolean) => {
-                        const next = new Set(noBundleUpdates());
+                        const next = new Set(noBundleUpdates(settings));
                         if (e) next.add("equicord");
                         else next.delete("equicord");
                         setConfig("noBundleUpdates", Array.from(next) as Settings["noBundleUpdates"], true);
@@ -567,9 +570,9 @@ export function SettingsPage() {
             </Show>
             <Show when={settings.mods.includes("custom")}>
                 <SwitchItem
-                    value={noBundleUpdates().includes("custom")}
+                    value={noBundleUpdates(settings).includes("custom")}
                     onChange={(e: boolean) => {
-                        const next = new Set(noBundleUpdates());
+                        const next = new Set(noBundleUpdates(settings));
                         if (e) next.add("custom");
                         else next.delete("custom");
                         setConfig("noBundleUpdates", Array.from(next) as Settings["noBundleUpdates"], true);

--- a/src/shelter/settings/pages/ThemesPage.tsx
+++ b/src/shelter/settings/pages/ThemesPage.tsx
@@ -9,7 +9,6 @@ const {
     ui: { Button, Header, HeaderTags, ButtonSizes, TextBox, showToast, SwitchItem },
     plugin: { store },
 } = shelter;
-const settings = store.settings as Settings;
 export function ThemesPage() {
     const [downloadUrl, setDownloadUrl] = createSignal("");
     refreshThemes();
@@ -27,13 +26,14 @@ export function ThemesPage() {
         });
     }
 
+    const settings = () => store.settings as Settings;
     const t = store.i18n;
     return (
         <>
             <Header tag={HeaderTags.H1}>Themes</Header>
             <SwitchItem
                 note={store.i18n["settings-quickCss-desc"]}
-                value={settings.quickCss}
+                value={settings().quickCss}
                 onChange={(e: boolean) => {
                     console.log("Toggled quick CSS", e);
                     if (e) {
@@ -50,7 +50,7 @@ export function ThemesPage() {
                 <Button
                     size={ButtonSizes.LARGE}
                     onClick={window.legcord.themes.openQuickCss}
-                    disabled={!settings.quickCss}
+                    disabled={!settings().quickCss}
                 >
                     {t["themes-openQuickCss"]}
                 </Button>

--- a/src/shelter/settings/settings.ts
+++ b/src/shelter/settings/settings.ts
@@ -4,8 +4,6 @@ const {
     plugin: { store },
 } = shelter;
 
-const settings = store.settings as Settings;
-
 export let isRestartRequired = false;
 
 export function setRestartRequired() {
@@ -21,7 +19,7 @@ export function refreshThemes() {
 }
 
 export function setConfig<K extends keyof Settings>(key: K, value: Settings[K], shouldRestart?: boolean) {
-    settings[key] = value;
+    store.settings[key] = value;
     console.log(key, ":", store.settings[key]);
     if (shouldRestart) {
         isRestartRequired = true;
@@ -36,7 +34,7 @@ function removeMod(array: ValidMods[], filter: ValidMods) {
 
 export function toggleMod(mod: ValidMods, enabled: boolean) {
     isRestartRequired = true;
-    const currentMods = settings.mods;
+    const currentMods = store.settings.mods;
     if (enabled) {
         if (mod === "vencord") {
             currentMods.push("vencord");


### PR DESCRIPTION
## Summary

Fix settings and themes pages rendering blank/white on first launch after setup.

## Problem

On first launch after completing the setup wizard, navigating to Legcord's settings or themes section in Discord's settings shows a blank white page. A restart fixes it.

Root cause: `const settings = store.settings as Settings` is evaluated at module load time by shelter, *before* `onLoad()` runs. Since the shelter store is empty until `onLoad()` calls `refreshSettings()`, the captured `settings` is always `undefined`. Additionally, the crash fallback accesses `store.i18n["settings-firstTimeCrash"]` — if `store.i18n` is also undefined at render time, this throws a TypeError, causing the entire settings section to render blank.

Same pattern in `ThemesPage.tsx:12` — `const settings = store.settings` at module level, `settings.quickCss` accessed during render → undefined access → crash → blank page.

## Solution

**SettingsPage.tsx** — Move `const settings` inside the `SettingsPage` component so it reflects the current `store.settings` on each render. Add `?.` optional chaining on all `store.i18n` accesses with English fallback text.

**settings.ts** — Remove the module-level `const settings = store.settings`. Replace `settings[key] = value` with `store.settings[key] = value` and `settings.mods` with `store.settings.mods` in `toggleMod`.

**index.ts** — Move `registerSection()` calls from module level into a `registerSections()` function called inside `onLoad()` (after `refreshSettings()` and `store.i18n` are set). This ensures all Legcord settings sections are registered *after* the store is populated.

**ThemesPage.tsx** — Move `const settings = store.settings` inside the component as a getter function `const settings = () => store.settings`.

## Risk

- `store.settings[key] = value` in `setConfig()`: if `store.settings` is undefined, this throws. Currently protected by the `if (!settings)` early return in `SettingsPage`.
- `registerSections()` called inside `onLoad()` instead of module level means sections appear slightly later (after `onLoad` finishes). No observable delay.
- `noBundleUpdates()` now takes `settings` as a parameter instead of closing over the module-level const — all call sites updated.
- Themes page `settings()` is now a getter function → accessed as `settings().quickCss` instead of `settings.quickCss`.

## Testing

- [x] `pnpm lint`
- [X] `pnpm build` (if this PR touches runtime code)
- [X] Manual verification: fresh install → setup wizard → navigate to Legcord settings → should render normally, not blank
- [X] Manual verification: themes page after first launch → should render, not blank
- [X] Manual verification: toggle settings → values persist correctly

## Notes

The same module-level capture pattern was checked in all 6 settings pages and sub-components. Only `SettingsPage.tsx` and `ThemesPage.tsx` had it. Pages using `store.settings.keybinds` or `store.i18n` directly (KeybindsPage, PluginsPage, RegisteredGamesPage, ThemesCard, KeybindCard, DetectableCard, PluginCard) were unaffected.