### PR TITLE
fix(screenshare): correct source card design

### DIFF
--- a/src/shelter/screenshare/components/SourceCard.module.css
+++ b/src/shelter/screenshare/components/SourceCard.module.css
@@ -9,14 +9,16 @@
         background-color 0.15s ease,
         transform 0.1s ease,
         border-color 0.25s ease;
-    border: 2px solid transparent;
+    border: 2px solid var(--background-modifier-accent);
     position: relative;
     user-select: none;
     overflow: visible;
+    background: var(--background-secondary);
 }
 
 .card:hover {
     background-color: var(--background-modifier-hover);
+    border-color: var(--background-modifier-selected);
 }
 
 .card:active {
@@ -25,11 +27,11 @@
 
 .cardSelected {
     border-color: var(--brand-experiment-560);
-    background-color: color-mix(in srgb, var(--brand-experiment-560) 10%, transparent);
+    background-color: color-mix(in srgb, var(--brand-experiment-560) 12%, var(--background-secondary));
 }
 
 .cardSelected:hover {
-    background-color: color-mix(in srgb, var(--brand-experiment-560) 16%, transparent);
+    background-color: color-mix(in srgb, var(--brand-experiment-560) 18%, var(--background-secondary));
 }
 
 .checkBadge {
@@ -89,8 +91,7 @@
     transition:
         opacity 0.2s ease,
         filter 0.2s ease;
-    opacity: 0.55;
-    filter: brightness(0.85);
+    opacity: 0.85;
 }
 
 .thumbnailSelected {
@@ -105,8 +106,7 @@
 }
 
 .card:hover .thumbnailUnselected {
-    opacity: 0.75;
-    filter: brightness(0.95);
+    opacity: 1;
 }
 
 .name {


### PR DESCRIPTION
## Summary

Fixes the screenshare source card design — cards had no background, invisible borders, and washed-out thumbnails.

## Problem

The source cards in the screenshare picker had a white/transparent background with no visible border, making them look broken. Thumbnails were heavily faded (opacity 0.55 + brightness 0.85), only showing proper colors on hover. The intended subtle outline and card appearance were missing.

## Solution

- Added `background: var(--background-secondary)` to `.card` so cards always have a proper background
- Changed default border from `transparent` to `var(--background-modifier-accent)` for a visible subtle outline
- Updated hover border to `var(--background-modifier-selected)` for better feedback
- Reduced thumbnail fading: opacity 0.85 (was 0.55), removed brightness filter
- Adjusted `.cardSelected` mix to use `--background-secondary` as base instead of `transparent`

## Risk

Low. Only CSS changes to `SourceCard.module.css`. No logic, component, or platform-specific code touched.

## Testing

- [x] `pnpm lint` — 0 errors, 1 pre-existing warning (electron-builder false positive)
- [ ] `pnpm build` if this PR touches runtime, bundling, or packaging code
- [x] Manual verification for affected flows
- [X] Screenshots or recordings for UI changes

## Notes

Only cosmetic CSS changes. The lint warning in `electron-builder.ts:8` is a Biome false positive — `\${version}`, `\${os}` etc. are electron-builder template placeholders, not JS template literals. Cannot be fixed without breaking the build.

BEFORE :

<img width="707" height="836" alt="image" src="https://github.com/user-attachments/assets/db9fe837-9501-44e5-b7aa-f3200828ea38" />


AFTER : 

<img width="772" height="804" alt="image" src="https://github.com/user-attachments/assets/0b53140e-60a3-41ee-9b5b-3c192ac97e2f" />
