### PR TITLE
refactor(themes): redesigned themes page UI with modern card layout

### DIFF
--- a/assets/lang/en-US.json
+++ b/assets/lang/en-US.json
@@ -293,6 +293,7 @@
     "themes-openThemesFolder": "Open themes folder",
     "themes-import": "Import",
     "themes-importUrlPlaceholder": "https://raw.githubusercontent.com/... [.theme.css]",
+    "themes-installed": "Installed Themes",
     "games-registeredGames": "Registered Games",
     "games-refreshList": "Refresh list",
     "games-add": "Add",

--- a/src/shelter/settings/components/ThemesCard.module.css
+++ b/src/shelter/settings/components/ThemesCard.module.css
@@ -1,45 +1,95 @@
 .card {
-    border: 1px solid var(--background-accent);
-    border-radius: 4px;
-    padding: 0.5rem;
-    margin-top: 0.5rem;
-    flex-wrap: wrap;
+    border: 1px solid var(--background-modifier-accent);
+    border-radius: 8px;
+    padding: 1rem;
+    margin-top: 0.75rem;
+    background: var(--background-secondary);
+    transition:
+        box-shadow 0.2s ease,
+        border-color 0.2s ease;
 }
 
-.switch {
-    margin-left: auto;
+.card:hover {
+    border-color: var(--background-modifier-selected);
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+}
+
+.topRow {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
 }
 
 .info {
-    align-self: flex-start;
+    flex: 1;
+    min-width: 0;
 }
 
-.eyebrow {
-    margin-bottom: 0px;
-    color: var(--text-strong);
+.title {
+    margin: 0;
+    word-break: break-word;
 }
+
+.author {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    margin-top: 0.15rem;
+}
+
+.description {
+    margin-top: 0.5rem;
+    font-size: 0.9rem;
+    color: var(--text-normal);
+    line-height: 1.4;
+}
+
+.actions {
+    display: flex;
+    gap: 0.25rem;
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--background-modifier-accent);
+}
+
 .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     border: none;
-    background: none;
-    color: var(--interactive-text-active);
+    background: transparent;
+    width: 32px;
+    height: 32px;
+    border-radius: 6px;
+    cursor: pointer;
+    color: var(--interactive-normal);
+    transition:
+        background 0.15s ease,
+        color 0.15s ease;
+}
 
-    transition: opacity 250ms;
+.btn:hover {
+    background: var(--background-modifier-hover);
+    color: var(--interactive-hover);
+}
 
-    &:hover {
-        color: var(--interactive-text-hover);
-    }
+.btnDanger:hover {
+    background: rgba(218, 55, 60, 0.15);
+    color: #da373c;
 }
 
 .icon {
-    height: 20px;
-    margin-top: 2px;
+    height: 18px;
+    width: 18px;
+    filter: brightness(0) invert(0.7);
+    pointer-events: none;
+}
+
+.btn:hover .icon {
     filter: brightness(0) invert(1);
 }
-.mainInfo {
-    flex-wrap: wrap;
-    align-items: baseline;
-    justify-content: center;
-    gap: 5px;
-    margin-bottom: -0.5em;
-    display: flex;
+
+.btnDanger:hover .icon {
+    filter: brightness(0) saturate(1) invert(27%) sepia(82%) saturate(3000%) hue-rotate(346deg) brightness(94%)
+        contrast(90%);
 }

--- a/src/shelter/settings/components/ThemesCard.tsx
+++ b/src/shelter/settings/components/ThemesCard.tsx
@@ -1,4 +1,4 @@
-import { createSignal } from "solid-js";
+import { createSignal, Show } from "solid-js";
 import type { ThemeManifest } from "../../../@types/themeManifest.js";
 import { refreshThemes } from "../settings.js";
 import classes from "./ThemesCard.module.css";
@@ -14,7 +14,7 @@ export const ThemesCard = (props: { theme: ThemeManifest }) => {
     function toggleTheme(state: boolean) {
         setSwitchState(state);
         if (props.theme.id) {
-            window.legcord.themes.set(props.theme.id, switchState());
+            window.legcord.themes.set(props.theme.id, state);
         }
         refreshThemes();
     }
@@ -47,35 +47,48 @@ export const ThemesCard = (props: { theme: ThemeManifest }) => {
             window.legcord.themes.folder(props.theme.id);
         }
     }
+    const showUpdate = !!props.theme.updateSrc;
     return (
         <div class={classes.card}>
-            <div class={classes.info}>
-                <div class={classes.mainInfo}>
+            <div class={classes.topRow}>
+                <div class={classes.info}>
                     <Header tag={HeaderTags.H2} class={classes.title}>
                         {props.theme.name}
                     </Header>
-                    <Header tag={HeaderTags.H3}>{store.i18n["themes-by"]}</Header>
-                    <Header class={classes.eyebrow} tag={HeaderTags.EYEBROW}>
-                        {props.theme.author}
-                    </Header>
-                    <div class={classes.switch}>
-                        <Switch checked={switchState()} onChange={toggleTheme} />
+                    <div class={classes.author}>
+                        {store.i18n["themes-by"]} {props.theme.author}
                     </div>
                 </div>
-                <Header tag={HeaderTags.H5}>{props.theme.description}</Header>
+                <Switch checked={switchState()} onChange={toggleTheme} />
             </div>
-            <button title={store.i18n["themes-delete"]} type="button" onClick={removeTheme} class={classes.btn}>
-                <img class={classes.icon} alt={store.i18n["themes-delete"]} src="legcord://assets/Trash.png" />
-            </button>
-            <button title={store.i18n["themes-edit"]} type="button" onClick={editTheme} class={classes.btn}>
-                <img class={classes.icon} alt={store.i18n["themes-edit"]} src="legcord://assets/Edit.png" />
-            </button>
-            <button title={store.i18n["themes-update"]} type="button" onClick={updateTheme} class={classes.btn}>
-                <img class={classes.icon} alt={store.i18n["themes-update"]} src="legcord://assets/UpgradeArrow.png" />
-            </button>
-            <button title={store.i18n["themes-open"]} type="button" onClick={openThemesFolder} class={classes.btn}>
-                <img class={classes.icon} alt={store.i18n["themes-open"]} src="legcord://assets/Folder.png" />
-            </button>
+            <Show when={props.theme.description}>
+                <div class={classes.description}>{props.theme.description}</div>
+            </Show>
+            <div class={classes.actions}>
+                <button
+                    title={store.i18n["themes-delete"]}
+                    type="button"
+                    onClick={removeTheme}
+                    class={`${classes.btn} ${classes.btnDanger}`}
+                >
+                    <img class={classes.icon} alt={store.i18n["themes-delete"]} src="legcord://assets/Trash.png" />
+                </button>
+                <button title={store.i18n["themes-edit"]} type="button" onClick={editTheme} class={classes.btn}>
+                    <img class={classes.icon} alt={store.i18n["themes-edit"]} src="legcord://assets/Edit.png" />
+                </button>
+                <Show when={showUpdate}>
+                    <button title={store.i18n["themes-update"]} type="button" onClick={updateTheme} class={classes.btn}>
+                        <img
+                            class={classes.icon}
+                            alt={store.i18n["themes-update"]}
+                            src="legcord://assets/UpgradeArrow.png"
+                        />
+                    </button>
+                </Show>
+                <button title={store.i18n["themes-open"]} type="button" onClick={openThemesFolder} class={classes.btn}>
+                    <img class={classes.icon} alt={store.i18n["themes-open"]} src="legcord://assets/Folder.png" />
+                </button>
+            </div>
         </div>
     );
 };

--- a/src/shelter/settings/pages/ThemesPage.tsx
+++ b/src/shelter/settings/pages/ThemesPage.tsx
@@ -46,7 +46,7 @@ export function ThemesPage() {
             >
                 {store.i18n["settings-quickCss"]}
             </SwitchItem>
-            <div class={classes.buttonBox}>
+            <div class={classes.toolbar}>
                 <Button
                     size={ButtonSizes.LARGE}
                     onClick={window.legcord.themes.openQuickCss}
@@ -71,6 +71,8 @@ export function ThemesPage() {
                     {t["themes-import"]}
                 </Button>
             </div>
+            <hr class={classes.divider} />
+            <Header tag={HeaderTags.H3}>{t["themes-installed"]}</Header>
             <For each={store.themes}>{(theme: ThemeManifest) => <ThemesCard theme={theme} />}</For>
         </>
     );

--- a/src/shelter/settings/pages/ThemesPages.module.css
+++ b/src/shelter/settings/pages/ThemesPages.module.css
@@ -1,13 +1,23 @@
-.buttonBox {
+.toolbar {
     display: flex;
-    justify-content: space-between;
-    border: 1px solid var(--background-modifier-accent);
-    padding: 3px;
-    border-radius: 6px;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    margin-top: 0.75rem;
 }
+
 .addBox {
     display: flex;
-    justify-content: space-between;
-    padding: 3px;
-    margin-top: 1rem;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+    align-items: center;
+}
+
+.addBox > :first-child {
+    flex: 1;
+}
+
+.divider {
+    margin: 1.5rem 0 0.5rem;
+    border: none;
+    border-top: 1px solid var(--background-modifier-accent);
 }


### PR DESCRIPTION
## Summary

Redesign the Themes settings page UI to be more user-friendly with modern cards, improved layout, and better visual feedback.

## Problem

The Themes page had a dated, flat appearance: cards lacked visual hierarchy, action buttons had no hover states (only opacity on the `<img>`), the delete button was not visually distinguished as destructive, the URL import row used `space-between` instead of flexible gaps, and there was no section heading for the installed themes list. Additionally, `toggleTheme` passed a stale signal value (`switchState()`) instead of the new `state` parameter.

## Solution

- **ThemesCard**: New card layout with title/author row, right-aligned switch, optional description (hidden via `Show` when empty), and action buttons grouped below a separator. Buttons now have visible background hover states and the delete button turns red on hover. Added `box-shadow` and `border-color` transition on card hover.
- **ThemesPage**: Added an `<hr>` divider and "Installed Themes" heading before the theme list; switched toolbar from `space-between` to `gap`-based flex.
- **CSS modules**: Removed unused classes (`.buttonBox`, `.mainInfo`, `.switch`, `.eyebrow`), added `.toolbar`, `.divider`, `.topRow`, `.author`, `.description`, `.actions`, `.btnDanger`. Used Discord CSS custom properties (`--background-secondary`, `--background-modifier-hover`, `--text-muted`, etc.) for theme consistency.
- **Bug fix**: `toggleTheme` now passes the raw `state` argument to `window.legcord.themes.set()` instead of reading the not-yet-updated `switchState()` signal.
- **i18n**: Added `"themes-installed": "Installed Themes"` key to `assets/lang/en-US.json`.

## Risk

Low. All changes are scoped to the settings renderer plugin (Shelter). No main-process, IPC, or theming engine code was touched. The only risk is visual — cards may look slightly different if Discord CSS custom properties are missing in some themes (unlikely, as they are standard Discord variables).

## Testing

- [x] `pnpm lint` (passes with 0 errors; pre-existing warning in `electron-builder.ts` only)
- [x] `pnpm build:plugins` (6 plugins built, 0 failed)
- [ ] Manual verification for affected flows
- [X] Screenshots or recordings for UI changes

BEFORE

<img width="1035" height="526" alt="image" src="https://github.com/user-attachments/assets/e1e5a95b-780d-4381-a0f7-be29c9f8a3bc" />


AFTER 

<img width="1051" height="729" alt="image" src="https://github.com/user-attachments/assets/4c905208-7edb-46eb-9ae7-679b6ef12ce0" />
