### PR TITLE
Fix metainfo to be fully compatable with Flathub

### DIFF
--- a/meta/app.legcord.Legcord.metainfo.xml
+++ b/meta/app.legcord.Legcord.metainfo.xml
@@ -4,7 +4,7 @@
   <id>app.legcord.Legcord</id>
   <name>Legcord</name>
   <summary>Legcord is a custom client designed to enhance your Discord experience while keeping everything lightweight.</summary>
-  <developer>
+  <developer id="app.legcord">
     <name>Legcord Contributors</name>
   </developer>
   <metadata_license>CC0-1.0</metadata_license>

--- a/meta/app.legcord.Legcord.metainfo.xml
+++ b/meta/app.legcord.Legcord.metainfo.xml
@@ -275,10 +275,6 @@
       <url>https://github.com/Legcord/Legcord/releases/tag/v1.0.2</url>
       <description/>
     </release>
-    <release version="devbuild" date="2024-10-12" type="development">
-      <url>https://github.com/Legcord/Legcord/releases/tag/devbuild</url>
-      <description/>
-    </release>
     <release version="v1.0.0" date="2024-10-11" type="stable">
       <url>https://github.com/Legcord/Legcord/releases/tag/v1.0.0</url>
       <description/>

--- a/meta/app.legcord.Legcord.metainfo.xml
+++ b/meta/app.legcord.Legcord.metainfo.xml
@@ -17,15 +17,15 @@
   <screenshots>
     <screenshot type="default">
       <caption>Legcord settings page on MacOS</caption>
-      <image type="source">https://github.com/Legcord/Legcord/blob/77e2ccafb221936a99654c237cb385d486780bc7/assets/screenshots/settings.png</image>
+      <image type="source">https://raw.githubusercontent.com/Legcord/Legcord/refs/tags/v1.2.4/assets/screenshots/settings.png</image>
     </screenshot>
     <screenshot>
       <caption>Legcord settings open with Shelter configs</caption>
-      <image type="source">https://github.com/Legcord/Legcord/blob/77e2ccafb221936a99654c237cb385d486780bc7/assets/screenshots/shelter.png</image>
+      <image type="source">https://raw.githubusercontent.com/Legcord/Legcord/refs/tags/v1.2.4/assets/screenshots/shelter.png</image>
     </screenshot>
     <screenshot>
       <caption>Legcord settings open with custom keybind settings shown</caption>
-      <image type="source">https://github.com/Legcord/Legcord/blob/77e2ccafb221936a99654c237cb385d486780bc7/assets/screenshots/keybinds.png</image>
+      <image type="source">https://raw.githubusercontent.com/Legcord/Legcord/refs/tags/v1.2.4/assets/screenshots/keybinds.png</image>
     </screenshot>
   </screenshots>
   <releases>

--- a/scripts/utils/updateMeta.ts
+++ b/scripts/utils/updateMeta.ts
@@ -50,6 +50,17 @@ const latestReleaseInformation = await fetch("https://api.github.com/repos/Legco
     },
 }).then((res) => res.json());
 
+// Ignore devbuild releases
+if (
+    latestReleaseInformation.name?.toLowerCase().includes("devbuild") ||
+    latestReleaseInformation.tag_name?.toLowerCase().includes("devbuild") ||
+    latestReleaseInformation.prerelease ||
+    latestReleaseInformation.draft
+) {
+    console.log("Latest release is a devbuild, nothing to be done");
+    process.exit(0);
+}
+
 const metaInfo = await fs.readFile("./meta/app.legcord.Legcord.metainfo.xml", "utf-8");
 
 const parser = new DOMParser().parseFromString(metaInfo, "text/xml");


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR changes. -->
Turned the links in <image> to actual raw images. (im kind of stupid, thats my bad lol)
Updated updateMeta.ts to always disregard devbuild releases.

## Problem

<!-- What issue, bug, feature request, or maintenance task does this address? -->
Flatpak builder linter issues `appstream-missing-screenshots` and `app.legcord.Legcord.metainfo.xml:releases-not-in-order`.

## Solution

<!-- What changed, and why is this the right approach? -->
Changed references in each <image> tag to it's raw.github equivalent and pinned it to current release as per Flathub guidelines.
Removed `devbuild` from the metainfo as that is causing problems.
Change updateMeta.ts to always disregard release `devbuild`, tag `devbuild`, draft releases and pre-releases.

## Risk

<!-- Call out anything that could regress, be platform-specific, or require extra review. -->

## Testing

<!-- Describe the checks you ran and any manual smoke tests. -->

- [x] `pnpm lint`
- [x] `pnpm build` if this PR touches runtime, bundling, or packaging code
- [x] Manual verification for affected flows
- [ ] Screenshots or recordings for UI changes

## Notes

<!-- Add links to related issues, screenshots, follow-up work, or implementation details. -->

Blocking flathub/flathub#9083