### PR TITLE
ci: upload generated-sources.json with releases (required for flatpak)

### DIFF
--- a/.github/workflows/flatpak-node.yml
+++ b/.github/workflows/flatpak-node.yml
@@ -1,0 +1,28 @@
+name: Upload generated-sources.json to release for Flatpak building
+
+on:
+    release:
+        types:
+            - published
+        workflow_dispatch:
+
+permissions:
+    contents: write
+
+jobs:
+    upload:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Install flatpak-node-generator
+              run: pipx install git+https://github.com/flatpak/flatpak-builder-tools.git#subdirectory=node
+
+            - name: Create generated-sources.json
+              run: /root/.local/bin/flatpak-node-generator pnpm pnpm-lock.yaml --node-sdk-extension org.freedesktop.Sdk.Extension.node26 --electron-node-headers
+
+            - name: Upload generated-sources.json to release
+              run: |
+                  gh release upload ${{ github.event.release.tag_name }} generated-sources.json
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/flatpak-node.yml
+++ b/.github/workflows/flatpak-node.yml
@@ -4,7 +4,7 @@ on:
     release:
         types:
             - published
-        workflow_dispatch:
+    workflow_dispatch:
 
 permissions:
     contents: write


### PR DESCRIPTION
## Summary
Add generated-sources.json to every release for flathub building.
<!-- Briefly describe what this PR changes. -->

## Problem
Right now, i manually generate the source based off the tag and move it to the flathub repo which isn't great for DX and it's also potentially dangerous.
<!-- What issue, bug, feature request, or maintenance task does this address? -->

## Solution
Add generated-sources.json to every release.
<!-- What changed, and why is this the right approach? -->

## Risk
slim to none; worse case is that it fails.
<!-- Call out anything that could regress, be platform-specific, or require extra review. -->

## Testing
Ran it locally with act and without the upload stage as it would break because i dont have auth.
<!-- Describe the checks you ran and any manual smoke tests. -->

- [ ] `pnpm lint`
- [ ] `pnpm build` if this PR touches runtime, bundling, or packaging code
- [x] Manual verification for affected flows
- [ ] Screenshots or recordings for UI changes

## Notes

<!-- Add links to related issues, screenshots, follow-up work, or implementation details. -->
