### PR TITLE
fix: use legcord:// protocol for local HTML files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
         "node": ">=26"
     },
     "scripts": {
-        "build:dev": "rollup -c --environment BUILD:dev && node scripts/copyVenmic.ts",
+        "build:dev": "rollup -c --environment BUILD:dev && node --experimental-strip-types scripts/copyVenmic.ts",
         "build:plugins": "lune ci --repoSubDir src/shelter --to ts-out/plugins",
-        "build": "pnpm build:plugins && rolldown -c rolldown.config.ts && node scripts/copyVenmic.ts",
+        "build": "pnpm build:plugins && rolldown -c rolldown.config.ts && node --experimental-strip-types scripts/copyVenmic.ts",
         "start": "pnpm run build && electron --trace-warnings --ozone-platform-hint=auto ./ts-out/main.js",
         "startThemeManager": "pnpm run build:dev && electron ./ts-out/main.js themes",
         "package": "pnpm run build && electron-builder",
@@ -18,7 +18,7 @@
         "lint:fix": "biome check --write",
         "postinstall": "electron-builder install-app-deps",
         "CIbuild": "pnpm run build && electron-builder --linux zip && electron-builder --windows zip && electron-builder --macos zip",
-        "updateMeta": "node scripts/utils/updateMeta.ts"
+        "updateMeta": "node --experimental-strip-types scripts/utils/updateMeta.ts"
     },
     "repository": {
         "type": "git",

--- a/src/cssEditor/main.ts
+++ b/src/cssEditor/main.ts
@@ -14,7 +14,7 @@ export function openCssEditor(file: string) {
             preload: path.join(import.meta.dirname, "cssEditor", "preload.mjs"),
         },
     });
-    cssWindow.loadURL(`file://${import.meta.dirname}/html/editor.html`);
+    cssWindow.loadURL("legcord://html/editor.html");
 
     ipcMain.on("editor-setCSS", (_event, css: string) => {
         fs.writeFileSync(file, css);

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -29,9 +29,39 @@ void app.whenReady().then(() => {
                 });
             }
             return net.fetch(Url.pathToFileURL(filePath).toString());
+        } else if (req.url.startsWith("legcord://html/")) {
+            const file = req.url.replace("legcord://html/", "");
+            const filePath = path.join(import.meta.dirname, "html", `${file}`);
+            if (filePath.includes("..")) {
+                return new Response("bad", {
+                    status: 400,
+                    headers: { "content-type": "text/html" },
+                });
+            }
+            return net.fetch(Url.pathToFileURL(filePath).toString());
+        } else if (req.url.startsWith("legcord://js/")) {
+            const file = req.url.replace("legcord://js/", "");
+            const filePath = path.join(import.meta.dirname, "js", `${file}`);
+            if (filePath.includes("..")) {
+                return new Response("bad", {
+                    status: 400,
+                    headers: { "content-type": "text/html" },
+                });
+            }
+            return net.fetch(Url.pathToFileURL(filePath).toString());
         } else if (req.url.startsWith("legcord://assets/")) {
             const file = req.url.replace("legcord://assets/", "");
             const filePath = path.join(import.meta.dirname, "assets", "app", `${file}`);
+            if (filePath.includes("..")) {
+                return new Response("bad", {
+                    status: 400,
+                    headers: { "content-type": "text/html" },
+                });
+            }
+            return net.fetch(Url.pathToFileURL(filePath).toString());
+        } else if (req.url.startsWith("legcord://css/")) {
+            const file = req.url.replace("legcord://css/", "");
+            const filePath = path.join(import.meta.dirname, "css", `${file}`);
             if (filePath.includes("..")) {
                 return new Response("bad", {
                     status: 400,

--- a/src/setup/main.ts
+++ b/src/setup/main.ts
@@ -22,7 +22,6 @@ export async function createSetupWindow(): Promise<void> {
             maximizable: false,
             autoHideMenuBar: true,
             webPreferences: {
-                sandbox: true,
                 spellcheck: false,
                 preload: path.join(import.meta.dirname, "setup", "preload.mjs"),
             },
@@ -70,6 +69,6 @@ export async function createSetupWindow(): Promise<void> {
             // workaround electron trying to relaunch from squashfs
             handleRestart();
         });
-        void setupWindow.loadFile(path.join(import.meta.dirname, "/html/setup.html"));
+        void setupWindow.loadURL("legcord://html/setup.html");
     });
 }

--- a/src/splash/main.ts
+++ b/src/splash/main.ts
@@ -31,5 +31,5 @@ export async function createSplashWindow(): Promise<void> {
     ipcMain.on("splash-clientmod", (event) => {
         event.returnValue = getConfig("mods");
     });
-    await splashWindow.loadFile(path.join(import.meta.dirname, "html", "splash.html"));
+    await splashWindow.loadURL("legcord://html/splash.html");
 }


### PR DESCRIPTION
## Summary

Fixes 3 issues: (1) first-launch crash in packaged builds because `loadFile` with asar paths fails with "Not allowed to load local resource", (2) Node 22 compatibility for `scripts/copyVenmic.ts` and `scripts/utils/updateMeta.ts`, (3) the `sandbox: true` leftover on the setup window not matching the splash window's config.

## Problem

Three issues were found while trying to build and run the dev branch on Windows:

1. **First-launch crash after packaging** — Installing the generated `.exe` and launching it for the first time opens the setup window, which calls `loadFile(path.join(import.meta.dirname, "/html/setup.html"))`. Inside an `.asar`, `import.meta.dirname` contains the path to the asar archive (e.g. `C:\Program Files\Legcord\resources\app.asar\ts-out`). Electron converts this to a `file://` URL, but Chromium treats `app.asar` as a file, not a directory, and throws: `Not allowed to load local resource: file:///.../app.asar/ts-out/html/setup.html`. The same pattern exists in `splash/main.ts` and `cssEditor/main.ts`.

2. **Node 22 compatibility** — The `package.json` engine requirement is `>=26`, but `copyVenmic.ts` and `updateMeta.ts` fail on Node 22 with `ERR_UNKNOWN_FILE_EXTENSION` because Node 22 doesn't natively strip TypeScript.

3. **`sandbox: true` mismatch** — The setup window had `sandbox: true` while the splash window (which does the same pattern — preload + local HTML loading) had `sandbox: false`. This wasn't the root cause but was inconsistent and contributed to the local resource restriction.

## Solution

1. **Switch to `legcord://` custom protocol for all local HTML loading** — Instead of `loadFile()` (which produces a `file://` URL), we now use `loadURL("legcord://html/...")`. This goes through Electron's registered privileged protocol handler, which uses `net.fetch()` (asar-aware) to serve files. Added three new routes:
   - `legcord://html/` — maps to `<dirname>/html/` (setup.html, splash.html, editor.html, setup.js)
   - `legcord://css/` — maps to `<dirname>/css/` (splash.css, referenced by splash.html via `@import url("../css/splash.css")`)
   - `legcord://js/` — maps to `<dirname>/js/` (for completeness, matching the existing rollup copy target)
   Updated `src/setup/main.ts`, `src/splash/main.ts`, and `src/cssEditor/main.ts` accordingly.

2. **Add `--experimental-strip-types` flag** — Added to the `build:dev`, `build`, and `updateMeta` scripts in `package.json` so that `.ts` scripts execute directly on Node 22+ without needing a separate compilation step.

3. **Remove `sandbox: true`** — Changed the setup window's `webPreferences` to omit `sandbox: true` (defaults to `false`), matching the splash window.

## Risk

Low. The protocol changes are isolated to loading local HTML/JS/CSS files for the setup, splash, and CSS editor windows — the main Discord window is unaffected (it loads from `https://discord.com/app`). The `--experimental-strip-types` flag is safe and actively used across the Node ecosystem. Removing `sandbox` from the setup window reduces isolation, but the window already has `contextIsolation: true` (default) and `nodeIntegration: false` (default), so security is still adequate — and it matches the splash window's configuration.

## Testing

- [x] `pnpm build` — succeeds with Node 22.14.0
- [x] `pnpm package` — generates installer without errors
- [x] Install generated `.exe` and launch — first-launch setup window renders correctly, no more "Not allowed to load local resource"
- [x] After completing setup, Discord main window loads normally
- [x] Mic fix (commit `d68a322`, already in dev branch) — confirmed the `getUserMedia` patch no longer kills audio streams on Windows

## Notes

The mic-drop issue that originally prompted this debug session (microphone randomly stopping mid-sentence) was caused by the `getUserMedia` override in `src/discord/preload/patches.mts` — Legcord v1.2.4 stopped **all previous audio streams** on every `getUserMedia` call. Discord makes multiple audio `getUserMedia` requests during a voice session, so each one killed the active mic stream. The fix (commit `d68a322`, post-v1.2.4) restricted this behavior to macOS only. No core audio code was touched in this PR since it was already fixed in the branch.