### PR TITLE
docs: add clipboard fallback plugin example

### DIFF
--- a/docs/examples/clipboard-fallback-plugin/README.md
+++ b/docs/examples/clipboard-fallback-plugin/README.md
@@ -5,8 +5,7 @@ Fixes Discord in-page copy actions in Legcord, including:
 - Copy User ID
 - Copy Message ID
 - Copy Message Link
-- Copy Image / rich clipboard payloads where Discord uses `navigator.clipboard.write(...)`
-- Other Discord menu actions that call `navigator.clipboard.writeText(...)` or `navigator.clipboard.write(...)`
+- Other Discord menu actions that call `navigator.clipboard.writeText(...)`
 
 ## Why this exists
 
@@ -28,9 +27,11 @@ or Legcord logs:
 Unable to determine render window for element [object HTMLDocument]
 ```
 
-This plugin patches `navigator.clipboard.writeText` and `navigator.clipboard.write` in the Discord page and falls back to a selection-based `document.execCommand("copy")` copy path.
+This plugin patches `navigator.clipboard.writeText` in the Discord page and falls back to a selection-based `document.execCommand("copy")` copy path.
 
-For image payloads, it converts the image Blob into a data URL, places it in a temporary off-screen editable element, selects it, and copies that selection. This is a browser fallback, so native Clipboard API image writes are still preferable when they work, but it covers the Legcord failure mode where Discord's Clipboard API call is blocked.
+## Known limitation
+
+Legcord's native **Copy Image** context-menu action does not go through `navigator.clipboard.writeText` or `navigator.clipboard.write` in the page. It is handled by Electron's main-process context menu (`webContents.copyImageAt(...)`), so a renderer/custom-bundle plugin cannot reliably fix image copying. That needs a Legcord main-process fix or a filesystem plugin with main/preload access on newer Legcord versions.
 
 ## Install on Legcord versions with filesystem plugins
 

--- a/docs/examples/clipboard-fallback-plugin/README.md
+++ b/docs/examples/clipboard-fallback-plugin/README.md
@@ -58,11 +58,13 @@ For image payloads, it converts the image Blob into a data URL, places it in a t
 
 ## Older Legcord workaround: custom bundle
 
-If your Legcord version does not have filesystem plugins yet, copy `renderer.js` into:
+If your Legcord version does not have filesystem plugins yet, copy `custom-bundle.js` into:
 
 ```text
 ~/Library/Application Support/legcord/custom.js
 ```
+
+Do **not** use `renderer.js` as `custom.js`; `renderer.js` is the filesystem-plugin entry and expects Legcord's plugin loader to provide `module.exports`.
 
 and add `"custom"` to the `mods` array in:
 

--- a/docs/examples/clipboard-fallback-plugin/README.md
+++ b/docs/examples/clipboard-fallback-plugin/README.md
@@ -1,19 +1,79 @@
-# Clipboard Fallback Plugin
+# Legcord Clipboard Fallback Plugin
 
-Fixes Discord in-page copy actions in Legcord by patching `navigator.clipboard.writeText` in the renderer and falling back to `document.execCommand("copy")`.
+Fixes Discord in-page copy actions in Legcord, including:
 
-This can help when actions like **Copy User ID**, **Copy Message ID**, or **Copy Message Link** leave the clipboard unchanged and logs include messages such as:
+- Copy User ID
+- Copy Message ID
+- Copy Message Link
+- Copy Image / rich clipboard payloads where Discord uses `navigator.clipboard.write(...)`
+- Other Discord menu actions that call `navigator.clipboard.writeText(...)` or `navigator.clipboard.write(...)`
+
+## Why this exists
+
+In affected Legcord/Electron environments, Discord's web UI calls:
+
+```js
+navigator.clipboard.writeText(text)
+```
+
+but Chromium rejects it, commonly with errors like:
+
+```text
+NotAllowedError: Failed to execute 'writeText' on 'Clipboard': Document is not focused.
+```
+
+or Legcord logs:
 
 ```text
 Unable to determine render window for element [object HTMLDocument]
 ```
 
-## Install
+This plugin patches `navigator.clipboard.writeText` and `navigator.clipboard.write` in the Discord page and falls back to a selection-based `document.execCommand("copy")` copy path.
 
-Copy this folder to your Legcord runtime plugins directory:
+For image payloads, it converts the image Blob into a data URL, places it in a temporary off-screen editable element, selects it, and copies that selection. This is a browser fallback, so native Clipboard API image writes are still preferable when they work, but it covers the Legcord failure mode where Discord's Clipboard API call is blocked.
+
+## Install on Legcord versions with filesystem plugins
+
+1. Open the Legcord plugins folder:
+
+   ```text
+   ~/Library/Application Support/legcord/plugins
+   ```
+
+2. Create this folder:
+
+   ```text
+   clipboard-fallback
+   ```
+
+3. Copy these files into it:
+
+   ```text
+   manifest.json
+   renderer.js
+   ```
+
+4. Restart Legcord.
+5. Enable **Clipboard Fallback** in Legcord's plugin settings.
+
+## Older Legcord workaround: custom bundle
+
+If your Legcord version does not have filesystem plugins yet, copy `renderer.js` into:
 
 ```text
-<userData>/plugins/clipboard-fallback
+~/Library/Application Support/legcord/custom.js
 ```
 
-Then restart Legcord and enable **Clipboard Fallback** in the Plugins settings page.
+and add `"custom"` to the `mods` array in:
+
+```text
+~/Library/Application Support/legcord/storage/settings.json
+```
+
+Example:
+
+```json
+"mods": ["equicord", "custom"]
+```
+
+Then restart Legcord.

--- a/docs/examples/clipboard-fallback-plugin/README.md
+++ b/docs/examples/clipboard-fallback-plugin/README.md
@@ -1,0 +1,19 @@
+# Clipboard Fallback Plugin
+
+Fixes Discord in-page copy actions in Legcord by patching `navigator.clipboard.writeText` in the renderer and falling back to `document.execCommand("copy")`.
+
+This can help when actions like **Copy User ID**, **Copy Message ID**, or **Copy Message Link** leave the clipboard unchanged and logs include messages such as:
+
+```text
+Unable to determine render window for element [object HTMLDocument]
+```
+
+## Install
+
+Copy this folder to your Legcord runtime plugins directory:
+
+```text
+<userData>/plugins/clipboard-fallback
+```
+
+Then restart Legcord and enable **Clipboard Fallback** in the Plugins settings page.

--- a/docs/examples/clipboard-fallback-plugin/custom-bundle.js
+++ b/docs/examples/clipboard-fallback-plugin/custom-bundle.js
@@ -1,0 +1,218 @@
+(() => {
+  const module = { exports: {} };
+  const exports = module.exports;
+  const api = {
+    logger: {
+      log: (...args) => console.log('[ClipboardFallback]', ...args),
+      warn: (...args) => console.warn('[ClipboardFallback]', ...args),
+      error: (...args) => console.error('[ClipboardFallback]', ...args),
+    },
+  };
+
+/**
+ * Legcord Clipboard Fallback
+ *
+ * Discord's web UI uses navigator.clipboard.writeText for actions such as
+ * "Copy User ID" and "Copy Message Link", and navigator.clipboard.write for
+ * richer clipboard payloads such as images. In some Legcord/Electron/macOS
+ * combinations Chromium rejects those calls because the document is not focused
+ * or the clipboard permission is not granted, leaving the clipboard unchanged.
+ *
+ * This renderer plugin replaces those APIs with selection-based copy fallbacks
+ * that run inside the original click gesture.
+ */
+module.exports.activate = (api) => {
+    const PATCH_KEY = Symbol.for("legcord.clipboardFallback.installed");
+
+    function install() {
+        try {
+            if (!navigator.clipboard) {
+                api.logger.warn("navigator.clipboard is unavailable");
+                return;
+            }
+
+            if (navigator.clipboard[PATCH_KEY]) return;
+
+            const originalWriteText = navigator.clipboard.writeText?.bind(navigator.clipboard);
+            const originalWrite = navigator.clipboard.write?.bind(navigator.clipboard);
+
+            async function blobToDataUrl(blob) {
+                if (typeof FileReader !== "undefined") {
+                    return await new Promise((resolve, reject) => {
+                        const reader = new FileReader();
+                        reader.onload = () => resolve(String(reader.result));
+                        reader.onerror = () => reject(reader.error ?? new Error("Failed to read clipboard image"));
+                        reader.readAsDataURL(blob);
+                    });
+                }
+
+                // Test/runtime fallback for environments with Blob but no FileReader.
+                const bytes = new Uint8Array(await blob.arrayBuffer());
+                let binary = "";
+                for (const byte of bytes) binary += String.fromCharCode(byte);
+                const base64 = typeof btoa === "function" ? btoa(binary) : Buffer.from(bytes).toString("base64");
+                return `data:${blob.type || "application/octet-stream"};base64,${base64}`;
+            }
+
+            function selectElementForCopy(element) {
+                const previousActiveElement = document.activeElement;
+                const selection = window.getSelection?.() ?? globalThis.getSelection?.();
+                const range = document.createRange();
+
+                element.focus?.();
+                range.selectNodeContents(element);
+                selection?.removeAllRanges();
+                selection?.addRange(range);
+
+                const copied = document.execCommand("copy");
+
+                selection?.removeAllRanges();
+                if (previousActiveElement && typeof previousActiveElement.focus === "function") {
+                    try {
+                        previousActiveElement.focus();
+                    } catch {}
+                }
+
+                if (!copied) throw new Error("document.execCommand('copy') returned false");
+            }
+
+            async function fallbackCopyText(text) {
+                const value = String(text);
+                const parent = document.body || document.documentElement;
+                if (!parent) throw new Error("No document body available for clipboard fallback");
+
+                const textarea = document.createElement("textarea");
+                textarea.value = value;
+                textarea.setAttribute("readonly", "");
+                textarea.setAttribute("aria-hidden", "true");
+                textarea.style.position = "fixed";
+                textarea.style.left = "-9999px";
+                textarea.style.top = "0";
+                textarea.style.width = "1px";
+                textarea.style.height = "1px";
+                textarea.style.opacity = "0";
+                textarea.style.pointerEvents = "none";
+
+                parent.appendChild(textarea);
+
+                const previousActiveElement = document.activeElement;
+                textarea.focus();
+                textarea.select();
+                textarea.setSelectionRange(0, value.length);
+
+                const copied = document.execCommand("copy");
+                textarea.remove();
+
+                if (previousActiveElement && typeof previousActiveElement.focus === "function") {
+                    try {
+                        previousActiveElement.focus();
+                    } catch {}
+                }
+
+                if (!copied) throw new Error("document.execCommand('copy') returned false");
+            }
+
+            async function getClipboardItemType(item, type) {
+                if (!item?.types?.includes(type) || typeof item.getType !== "function") return null;
+                return await item.getType(type);
+            }
+
+            async function fallbackCopyItems(items) {
+                const parent = document.body || document.documentElement;
+                if (!parent) throw new Error("No document body available for clipboard fallback");
+
+                const container = document.createElement("div");
+                container.contentEditable = "true";
+                container.setAttribute("aria-hidden", "true");
+                container.style.position = "fixed";
+                container.style.left = "-9999px";
+                container.style.top = "0";
+                container.style.width = "1px";
+                container.style.height = "1px";
+                container.style.overflow = "hidden";
+
+                for (const item of items) {
+                    const htmlBlob = await getClipboardItemType(item, "text/html");
+                    if (htmlBlob) {
+                        container.innerHTML += await htmlBlob.text();
+                        continue;
+                    }
+
+                    const textBlob = await getClipboardItemType(item, "text/plain");
+                    if (textBlob) {
+                        const span = document.createElement("span");
+                        span.textContent = await textBlob.text();
+                        container.appendChild(span);
+                        continue;
+                    }
+
+                    const imageType = item?.types?.find((type) => type.startsWith("image/"));
+                    if (imageType && typeof item.getType === "function") {
+                        const imageBlob = await item.getType(imageType);
+                        const image = document.createElement("img");
+                        image.src = await blobToDataUrl(imageBlob);
+                        image.alt = "";
+                        container.appendChild(image);
+                    }
+                }
+
+                if (!container.innerHTML && !container.textContent && !container.children?.length) {
+                    throw new Error("No supported clipboard item types found");
+                }
+
+                parent.appendChild(container);
+                selectElementForCopy(container);
+                container.remove();
+            }
+
+            if (originalWriteText) {
+                Object.defineProperty(navigator.clipboard, "writeText", {
+                    configurable: true,
+                    value: async (text) => {
+                        try {
+                            await fallbackCopyText(text);
+                            api.logger.log("copied text via fallback", text);
+                        } catch (fallbackError) {
+                            api.logger.warn("text fallback failed; trying original writeText", fallbackError);
+                            return originalWriteText(text);
+                        }
+                    },
+                });
+            }
+
+            if (originalWrite) {
+                Object.defineProperty(navigator.clipboard, "write", {
+                    configurable: true,
+                    value: async (items) => {
+                        try {
+                            await fallbackCopyItems(items);
+                            api.logger.log("copied rich clipboard payload via fallback");
+                        } catch (fallbackError) {
+                            api.logger.warn("rich clipboard fallback failed; trying original write", fallbackError);
+                            return originalWrite(items);
+                        }
+                    },
+                });
+            }
+
+            Object.defineProperty(navigator.clipboard, PATCH_KEY, {
+                configurable: false,
+                enumerable: false,
+                value: true,
+            });
+
+            api.logger.log("installed");
+        } catch (error) {
+            api.logger.error("install failed", error);
+        }
+    }
+
+    install();
+    window.addEventListener("DOMContentLoaded", install, { once: true });
+};
+
+
+  if (typeof module.exports.activate === 'function') {
+    module.exports.activate(api);
+  }
+})();

--- a/docs/examples/clipboard-fallback-plugin/custom-bundle.js
+++ b/docs/examples/clipboard-fallback-plugin/custom-bundle.js
@@ -1,218 +1,216 @@
 (() => {
-  const module = { exports: {} };
-  const exports = module.exports;
-  const api = {
-    logger: {
-      log: (...args) => console.log('[ClipboardFallback]', ...args),
-      warn: (...args) => console.warn('[ClipboardFallback]', ...args),
-      error: (...args) => console.error('[ClipboardFallback]', ...args),
-    },
-  };
+    const module = { exports: {} };
+    const api = {
+        logger: {
+            log: (...args) => console.log("[ClipboardFallback]", ...args),
+            warn: (...args) => console.warn("[ClipboardFallback]", ...args),
+            error: (...args) => console.error("[ClipboardFallback]", ...args),
+        },
+    };
 
-/**
- * Legcord Clipboard Fallback
- *
- * Discord's web UI uses navigator.clipboard.writeText for actions such as
- * "Copy User ID" and "Copy Message Link", and navigator.clipboard.write for
- * richer clipboard payloads such as images. In some Legcord/Electron/macOS
- * combinations Chromium rejects those calls because the document is not focused
- * or the clipboard permission is not granted, leaving the clipboard unchanged.
- *
- * This renderer plugin replaces those APIs with selection-based copy fallbacks
- * that run inside the original click gesture.
- */
-module.exports.activate = (api) => {
-    const PATCH_KEY = Symbol.for("legcord.clipboardFallback.installed");
+    /**
+     * Legcord Clipboard Fallback
+     *
+     * Discord's web UI uses navigator.clipboard.writeText for actions such as
+     * "Copy User ID" and "Copy Message Link", and navigator.clipboard.write for
+     * richer clipboard payloads such as images. In some Legcord/Electron/macOS
+     * combinations Chromium rejects those calls because the document is not focused
+     * or the clipboard permission is not granted, leaving the clipboard unchanged.
+     *
+     * This renderer plugin replaces those APIs with selection-based copy fallbacks
+     * that run inside the original click gesture.
+     */
+    module.exports.activate = (api) => {
+        const PATCH_KEY = Symbol.for("legcord.clipboardFallback.installed");
 
-    function install() {
-        try {
-            if (!navigator.clipboard) {
-                api.logger.warn("navigator.clipboard is unavailable");
-                return;
-            }
+        function install() {
+            try {
+                if (!navigator.clipboard) {
+                    api.logger.warn("navigator.clipboard is unavailable");
+                    return;
+                }
 
-            if (navigator.clipboard[PATCH_KEY]) return;
+                if (navigator.clipboard[PATCH_KEY]) return;
 
-            const originalWriteText = navigator.clipboard.writeText?.bind(navigator.clipboard);
-            const originalWrite = navigator.clipboard.write?.bind(navigator.clipboard);
+                const originalWriteText = navigator.clipboard.writeText?.bind(navigator.clipboard);
+                const originalWrite = navigator.clipboard.write?.bind(navigator.clipboard);
 
-            async function blobToDataUrl(blob) {
-                if (typeof FileReader !== "undefined") {
-                    return await new Promise((resolve, reject) => {
-                        const reader = new FileReader();
-                        reader.onload = () => resolve(String(reader.result));
-                        reader.onerror = () => reject(reader.error ?? new Error("Failed to read clipboard image"));
-                        reader.readAsDataURL(blob);
+                async function blobToDataUrl(blob) {
+                    if (typeof FileReader !== "undefined") {
+                        return await new Promise((resolve, reject) => {
+                            const reader = new FileReader();
+                            reader.onload = () => resolve(String(reader.result));
+                            reader.onerror = () => reject(reader.error ?? new Error("Failed to read clipboard image"));
+                            reader.readAsDataURL(blob);
+                        });
+                    }
+
+                    // Test/runtime fallback for environments with Blob but no FileReader.
+                    const bytes = new Uint8Array(await blob.arrayBuffer());
+                    let binary = "";
+                    for (const byte of bytes) binary += String.fromCharCode(byte);
+                    const base64 = typeof btoa === "function" ? btoa(binary) : Buffer.from(bytes).toString("base64");
+                    return `data:${blob.type || "application/octet-stream"};base64,${base64}`;
+                }
+
+                function selectElementForCopy(element) {
+                    const previousActiveElement = document.activeElement;
+                    const selection = window.getSelection?.() ?? globalThis.getSelection?.();
+                    const range = document.createRange();
+
+                    element.focus?.();
+                    range.selectNodeContents(element);
+                    selection?.removeAllRanges();
+                    selection?.addRange(range);
+
+                    const copied = document.execCommand("copy");
+
+                    selection?.removeAllRanges();
+                    if (previousActiveElement && typeof previousActiveElement.focus === "function") {
+                        try {
+                            previousActiveElement.focus();
+                        } catch {}
+                    }
+
+                    if (!copied) throw new Error("document.execCommand('copy') returned false");
+                }
+
+                async function fallbackCopyText(text) {
+                    const value = String(text);
+                    const parent = document.body || document.documentElement;
+                    if (!parent) throw new Error("No document body available for clipboard fallback");
+
+                    const textarea = document.createElement("textarea");
+                    textarea.value = value;
+                    textarea.setAttribute("readonly", "");
+                    textarea.setAttribute("aria-hidden", "true");
+                    textarea.style.position = "fixed";
+                    textarea.style.left = "-9999px";
+                    textarea.style.top = "0";
+                    textarea.style.width = "1px";
+                    textarea.style.height = "1px";
+                    textarea.style.opacity = "0";
+                    textarea.style.pointerEvents = "none";
+
+                    parent.appendChild(textarea);
+
+                    const previousActiveElement = document.activeElement;
+                    textarea.focus();
+                    textarea.select();
+                    textarea.setSelectionRange(0, value.length);
+
+                    const copied = document.execCommand("copy");
+                    textarea.remove();
+
+                    if (previousActiveElement && typeof previousActiveElement.focus === "function") {
+                        try {
+                            previousActiveElement.focus();
+                        } catch {}
+                    }
+
+                    if (!copied) throw new Error("document.execCommand('copy') returned false");
+                }
+
+                async function getClipboardItemType(item, type) {
+                    if (!item?.types?.includes(type) || typeof item.getType !== "function") return null;
+                    return await item.getType(type);
+                }
+
+                async function fallbackCopyItems(items) {
+                    const parent = document.body || document.documentElement;
+                    if (!parent) throw new Error("No document body available for clipboard fallback");
+
+                    const container = document.createElement("div");
+                    container.contentEditable = "true";
+                    container.setAttribute("aria-hidden", "true");
+                    container.style.position = "fixed";
+                    container.style.left = "-9999px";
+                    container.style.top = "0";
+                    container.style.width = "1px";
+                    container.style.height = "1px";
+                    container.style.overflow = "hidden";
+
+                    for (const item of items) {
+                        const htmlBlob = await getClipboardItemType(item, "text/html");
+                        if (htmlBlob) {
+                            container.innerHTML += await htmlBlob.text();
+                            continue;
+                        }
+
+                        const textBlob = await getClipboardItemType(item, "text/plain");
+                        if (textBlob) {
+                            const span = document.createElement("span");
+                            span.textContent = await textBlob.text();
+                            container.appendChild(span);
+                            continue;
+                        }
+
+                        const imageType = item?.types?.find((type) => type.startsWith("image/"));
+                        if (imageType && typeof item.getType === "function") {
+                            const imageBlob = await item.getType(imageType);
+                            const image = document.createElement("img");
+                            image.src = await blobToDataUrl(imageBlob);
+                            image.alt = "";
+                            container.appendChild(image);
+                        }
+                    }
+
+                    if (!container.innerHTML && !container.textContent && !container.children?.length) {
+                        throw new Error("No supported clipboard item types found");
+                    }
+
+                    parent.appendChild(container);
+                    selectElementForCopy(container);
+                    container.remove();
+                }
+
+                if (originalWriteText) {
+                    Object.defineProperty(navigator.clipboard, "writeText", {
+                        configurable: true,
+                        value: async (text) => {
+                            try {
+                                await fallbackCopyText(text);
+                                api.logger.log("copied text via fallback", text);
+                            } catch (fallbackError) {
+                                api.logger.warn("text fallback failed; trying original writeText", fallbackError);
+                                return originalWriteText(text);
+                            }
+                        },
                     });
                 }
 
-                // Test/runtime fallback for environments with Blob but no FileReader.
-                const bytes = new Uint8Array(await blob.arrayBuffer());
-                let binary = "";
-                for (const byte of bytes) binary += String.fromCharCode(byte);
-                const base64 = typeof btoa === "function" ? btoa(binary) : Buffer.from(bytes).toString("base64");
-                return `data:${blob.type || "application/octet-stream"};base64,${base64}`;
-            }
-
-            function selectElementForCopy(element) {
-                const previousActiveElement = document.activeElement;
-                const selection = window.getSelection?.() ?? globalThis.getSelection?.();
-                const range = document.createRange();
-
-                element.focus?.();
-                range.selectNodeContents(element);
-                selection?.removeAllRanges();
-                selection?.addRange(range);
-
-                const copied = document.execCommand("copy");
-
-                selection?.removeAllRanges();
-                if (previousActiveElement && typeof previousActiveElement.focus === "function") {
-                    try {
-                        previousActiveElement.focus();
-                    } catch {}
+                if (originalWrite) {
+                    Object.defineProperty(navigator.clipboard, "write", {
+                        configurable: true,
+                        value: async (items) => {
+                            try {
+                                await fallbackCopyItems(items);
+                                api.logger.log("copied rich clipboard payload via fallback");
+                            } catch (fallbackError) {
+                                api.logger.warn("rich clipboard fallback failed; trying original write", fallbackError);
+                                return originalWrite(items);
+                            }
+                        },
+                    });
                 }
 
-                if (!copied) throw new Error("document.execCommand('copy') returned false");
-            }
-
-            async function fallbackCopyText(text) {
-                const value = String(text);
-                const parent = document.body || document.documentElement;
-                if (!parent) throw new Error("No document body available for clipboard fallback");
-
-                const textarea = document.createElement("textarea");
-                textarea.value = value;
-                textarea.setAttribute("readonly", "");
-                textarea.setAttribute("aria-hidden", "true");
-                textarea.style.position = "fixed";
-                textarea.style.left = "-9999px";
-                textarea.style.top = "0";
-                textarea.style.width = "1px";
-                textarea.style.height = "1px";
-                textarea.style.opacity = "0";
-                textarea.style.pointerEvents = "none";
-
-                parent.appendChild(textarea);
-
-                const previousActiveElement = document.activeElement;
-                textarea.focus();
-                textarea.select();
-                textarea.setSelectionRange(0, value.length);
-
-                const copied = document.execCommand("copy");
-                textarea.remove();
-
-                if (previousActiveElement && typeof previousActiveElement.focus === "function") {
-                    try {
-                        previousActiveElement.focus();
-                    } catch {}
-                }
-
-                if (!copied) throw new Error("document.execCommand('copy') returned false");
-            }
-
-            async function getClipboardItemType(item, type) {
-                if (!item?.types?.includes(type) || typeof item.getType !== "function") return null;
-                return await item.getType(type);
-            }
-
-            async function fallbackCopyItems(items) {
-                const parent = document.body || document.documentElement;
-                if (!parent) throw new Error("No document body available for clipboard fallback");
-
-                const container = document.createElement("div");
-                container.contentEditable = "true";
-                container.setAttribute("aria-hidden", "true");
-                container.style.position = "fixed";
-                container.style.left = "-9999px";
-                container.style.top = "0";
-                container.style.width = "1px";
-                container.style.height = "1px";
-                container.style.overflow = "hidden";
-
-                for (const item of items) {
-                    const htmlBlob = await getClipboardItemType(item, "text/html");
-                    if (htmlBlob) {
-                        container.innerHTML += await htmlBlob.text();
-                        continue;
-                    }
-
-                    const textBlob = await getClipboardItemType(item, "text/plain");
-                    if (textBlob) {
-                        const span = document.createElement("span");
-                        span.textContent = await textBlob.text();
-                        container.appendChild(span);
-                        continue;
-                    }
-
-                    const imageType = item?.types?.find((type) => type.startsWith("image/"));
-                    if (imageType && typeof item.getType === "function") {
-                        const imageBlob = await item.getType(imageType);
-                        const image = document.createElement("img");
-                        image.src = await blobToDataUrl(imageBlob);
-                        image.alt = "";
-                        container.appendChild(image);
-                    }
-                }
-
-                if (!container.innerHTML && !container.textContent && !container.children?.length) {
-                    throw new Error("No supported clipboard item types found");
-                }
-
-                parent.appendChild(container);
-                selectElementForCopy(container);
-                container.remove();
-            }
-
-            if (originalWriteText) {
-                Object.defineProperty(navigator.clipboard, "writeText", {
-                    configurable: true,
-                    value: async (text) => {
-                        try {
-                            await fallbackCopyText(text);
-                            api.logger.log("copied text via fallback", text);
-                        } catch (fallbackError) {
-                            api.logger.warn("text fallback failed; trying original writeText", fallbackError);
-                            return originalWriteText(text);
-                        }
-                    },
+                Object.defineProperty(navigator.clipboard, PATCH_KEY, {
+                    configurable: false,
+                    enumerable: false,
+                    value: true,
                 });
+
+                api.logger.log("installed");
+            } catch (error) {
+                api.logger.error("install failed", error);
             }
-
-            if (originalWrite) {
-                Object.defineProperty(navigator.clipboard, "write", {
-                    configurable: true,
-                    value: async (items) => {
-                        try {
-                            await fallbackCopyItems(items);
-                            api.logger.log("copied rich clipboard payload via fallback");
-                        } catch (fallbackError) {
-                            api.logger.warn("rich clipboard fallback failed; trying original write", fallbackError);
-                            return originalWrite(items);
-                        }
-                    },
-                });
-            }
-
-            Object.defineProperty(navigator.clipboard, PATCH_KEY, {
-                configurable: false,
-                enumerable: false,
-                value: true,
-            });
-
-            api.logger.log("installed");
-        } catch (error) {
-            api.logger.error("install failed", error);
         }
+
+        install();
+        window.addEventListener("DOMContentLoaded", install, { once: true });
+    };
+
+    if (typeof module.exports.activate === "function") {
+        module.exports.activate(api);
     }
-
-    install();
-    window.addEventListener("DOMContentLoaded", install, { once: true });
-};
-
-
-  if (typeof module.exports.activate === 'function') {
-    module.exports.activate(api);
-  }
 })();

--- a/docs/examples/clipboard-fallback-plugin/manifest.json
+++ b/docs/examples/clipboard-fallback-plugin/manifest.json
@@ -1,8 +1,8 @@
 {
   "id": "clipboard-fallback",
   "name": "Clipboard Fallback",
-  "version": "1.0.0",
-  "description": "Fixes Discord in-page copy actions in Legcord by falling back to document.execCommand('copy') when navigator.clipboard.writeText is blocked.",
+  "version": "1.1.0",
+  "description": "Fixes Discord in-page text and image copy actions in Legcord by falling back to document.execCommand('copy') when Clipboard API writes are blocked.",
   "author": "Nigel Thornberry",
   "compatibleVersions": ["*"],
   "renderer": "renderer.js"

--- a/docs/examples/clipboard-fallback-plugin/manifest.json
+++ b/docs/examples/clipboard-fallback-plugin/manifest.json
@@ -1,0 +1,9 @@
+{
+  "id": "clipboard-fallback",
+  "name": "Clipboard Fallback",
+  "version": "1.0.0",
+  "description": "Fixes Discord in-page copy actions in Legcord by falling back to document.execCommand('copy') when navigator.clipboard.writeText is blocked.",
+  "author": "Nigel Thornberry",
+  "compatibleVersions": ["*"],
+  "renderer": "renderer.js"
+}

--- a/docs/examples/clipboard-fallback-plugin/manifest.json
+++ b/docs/examples/clipboard-fallback-plugin/manifest.json
@@ -2,7 +2,7 @@
   "id": "clipboard-fallback",
   "name": "Clipboard Fallback",
   "version": "1.1.0",
-  "description": "Fixes Discord in-page text and image copy actions in Legcord by falling back to document.execCommand('copy') when Clipboard API writes are blocked.",
+  "description": "Fixes Discord in-page text copy actions in Legcord by falling back to document.execCommand('copy') when navigator.clipboard.writeText is blocked.",
   "author": "Nigel Thornberry",
   "compatibleVersions": ["*"],
   "renderer": "renderer.js"

--- a/docs/examples/clipboard-fallback-plugin/manifest.json
+++ b/docs/examples/clipboard-fallback-plugin/manifest.json
@@ -1,9 +1,9 @@
 {
-  "id": "clipboard-fallback",
-  "name": "Clipboard Fallback",
-  "version": "1.1.0",
-  "description": "Fixes Discord in-page text copy actions in Legcord by falling back to document.execCommand('copy') when navigator.clipboard.writeText is blocked.",
-  "author": "Nigel Thornberry",
-  "compatibleVersions": ["*"],
-  "renderer": "renderer.js"
+    "id": "clipboard-fallback",
+    "name": "Clipboard Fallback",
+    "version": "1.1.0",
+    "description": "Fixes Discord in-page text copy actions in Legcord by falling back to document.execCommand('copy') when navigator.clipboard.writeText is blocked.",
+    "author": "Nigel Thornberry",
+    "compatibleVersions": ["*"],
+    "renderer": "renderer.js"
 }

--- a/docs/examples/clipboard-fallback-plugin/renderer.js
+++ b/docs/examples/clipboard-fallback-plugin/renderer.js
@@ -2,29 +2,70 @@
  * Legcord Clipboard Fallback
  *
  * Discord's web UI uses navigator.clipboard.writeText for actions such as
- * "Copy User ID" and "Copy Message Link". In some Legcord/Electron/macOS
- * combinations Chromium rejects that call because the document is not focused
+ * "Copy User ID" and "Copy Message Link", and navigator.clipboard.write for
+ * richer clipboard payloads such as images. In some Legcord/Electron/macOS
+ * combinations Chromium rejects those calls because the document is not focused
  * or the clipboard permission is not granted, leaving the clipboard unchanged.
  *
- * This renderer plugin replaces writeText with a selection-based copy fallback
- * that runs inside the original click gesture.
+ * This renderer plugin replaces those APIs with selection-based copy fallbacks
+ * that run inside the original click gesture.
  */
 module.exports.activate = (api) => {
-    const TAG = "[ClipboardFallback]";
     const PATCH_KEY = Symbol.for("legcord.clipboardFallback.installed");
 
     function install() {
         try {
-            if (!navigator.clipboard?.writeText) {
-                api.logger.warn("navigator.clipboard.writeText is unavailable");
+            if (!navigator.clipboard) {
+                api.logger.warn("navigator.clipboard is unavailable");
                 return;
             }
 
             if (navigator.clipboard[PATCH_KEY]) return;
 
-            const originalWriteText = navigator.clipboard.writeText.bind(navigator.clipboard);
+            const originalWriteText = navigator.clipboard.writeText?.bind(navigator.clipboard);
+            const originalWrite = navigator.clipboard.write?.bind(navigator.clipboard);
 
-            async function fallbackCopy(text) {
+            async function blobToDataUrl(blob) {
+                if (typeof FileReader !== "undefined") {
+                    return await new Promise((resolve, reject) => {
+                        const reader = new FileReader();
+                        reader.onload = () => resolve(String(reader.result));
+                        reader.onerror = () => reject(reader.error ?? new Error("Failed to read clipboard image"));
+                        reader.readAsDataURL(blob);
+                    });
+                }
+
+                // Test/runtime fallback for environments with Blob but no FileReader.
+                const bytes = new Uint8Array(await blob.arrayBuffer());
+                let binary = "";
+                for (const byte of bytes) binary += String.fromCharCode(byte);
+                const base64 = typeof btoa === "function" ? btoa(binary) : Buffer.from(bytes).toString("base64");
+                return `data:${blob.type || "application/octet-stream"};base64,${base64}`;
+            }
+
+            function selectElementForCopy(element) {
+                const previousActiveElement = document.activeElement;
+                const selection = window.getSelection?.() ?? globalThis.getSelection?.();
+                const range = document.createRange();
+
+                element.focus?.();
+                range.selectNodeContents(element);
+                selection?.removeAllRanges();
+                selection?.addRange(range);
+
+                const copied = document.execCommand("copy");
+
+                selection?.removeAllRanges();
+                if (previousActiveElement && typeof previousActiveElement.focus === "function") {
+                    try {
+                        previousActiveElement.focus();
+                    } catch {}
+                }
+
+                if (!copied) throw new Error("document.execCommand('copy') returned false");
+            }
+
+            async function fallbackCopyText(text) {
                 const value = String(text);
                 const parent = document.body || document.documentElement;
                 if (!parent) throw new Error("No document body available for clipboard fallback");
@@ -60,18 +101,88 @@ module.exports.activate = (api) => {
                 if (!copied) throw new Error("document.execCommand('copy') returned false");
             }
 
-            Object.defineProperty(navigator.clipboard, "writeText", {
-                configurable: true,
-                value: async (text) => {
-                    try {
-                        await fallbackCopy(text);
-                        api.logger.log("copied via fallback", text);
-                    } catch (fallbackError) {
-                        api.logger.warn("fallback failed; trying original writeText", fallbackError);
-                        return originalWriteText(text);
+            async function getClipboardItemType(item, type) {
+                if (!item?.types?.includes(type) || typeof item.getType !== "function") return null;
+                return await item.getType(type);
+            }
+
+            async function fallbackCopyItems(items) {
+                const parent = document.body || document.documentElement;
+                if (!parent) throw new Error("No document body available for clipboard fallback");
+
+                const container = document.createElement("div");
+                container.contentEditable = "true";
+                container.setAttribute("aria-hidden", "true");
+                container.style.position = "fixed";
+                container.style.left = "-9999px";
+                container.style.top = "0";
+                container.style.width = "1px";
+                container.style.height = "1px";
+                container.style.overflow = "hidden";
+
+                for (const item of items) {
+                    const htmlBlob = await getClipboardItemType(item, "text/html");
+                    if (htmlBlob) {
+                        container.innerHTML += await htmlBlob.text();
+                        continue;
                     }
-                },
-            });
+
+                    const textBlob = await getClipboardItemType(item, "text/plain");
+                    if (textBlob) {
+                        const span = document.createElement("span");
+                        span.textContent = await textBlob.text();
+                        container.appendChild(span);
+                        continue;
+                    }
+
+                    const imageType = item?.types?.find((type) => type.startsWith("image/"));
+                    if (imageType && typeof item.getType === "function") {
+                        const imageBlob = await item.getType(imageType);
+                        const image = document.createElement("img");
+                        image.src = await blobToDataUrl(imageBlob);
+                        image.alt = "";
+                        container.appendChild(image);
+                    }
+                }
+
+                if (!container.innerHTML && !container.textContent && !container.children?.length) {
+                    throw new Error("No supported clipboard item types found");
+                }
+
+                parent.appendChild(container);
+                selectElementForCopy(container);
+                container.remove();
+            }
+
+            if (originalWriteText) {
+                Object.defineProperty(navigator.clipboard, "writeText", {
+                    configurable: true,
+                    value: async (text) => {
+                        try {
+                            await fallbackCopyText(text);
+                            api.logger.log("copied text via fallback", text);
+                        } catch (fallbackError) {
+                            api.logger.warn("text fallback failed; trying original writeText", fallbackError);
+                            return originalWriteText(text);
+                        }
+                    },
+                });
+            }
+
+            if (originalWrite) {
+                Object.defineProperty(navigator.clipboard, "write", {
+                    configurable: true,
+                    value: async (items) => {
+                        try {
+                            await fallbackCopyItems(items);
+                            api.logger.log("copied rich clipboard payload via fallback");
+                        } catch (fallbackError) {
+                            api.logger.warn("rich clipboard fallback failed; trying original write", fallbackError);
+                            return originalWrite(items);
+                        }
+                    },
+                });
+            }
 
             Object.defineProperty(navigator.clipboard, PATCH_KEY, {
                 configurable: false,

--- a/docs/examples/clipboard-fallback-plugin/renderer.js
+++ b/docs/examples/clipboard-fallback-plugin/renderer.js
@@ -1,0 +1,90 @@
+/**
+ * Legcord Clipboard Fallback
+ *
+ * Discord's web UI uses navigator.clipboard.writeText for actions such as
+ * "Copy User ID" and "Copy Message Link". In some Legcord/Electron/macOS
+ * combinations Chromium rejects that call because the document is not focused
+ * or the clipboard permission is not granted, leaving the clipboard unchanged.
+ *
+ * This renderer plugin replaces writeText with a selection-based copy fallback
+ * that runs inside the original click gesture.
+ */
+module.exports.activate = (api) => {
+    const TAG = "[ClipboardFallback]";
+    const PATCH_KEY = Symbol.for("legcord.clipboardFallback.installed");
+
+    function install() {
+        try {
+            if (!navigator.clipboard?.writeText) {
+                api.logger.warn("navigator.clipboard.writeText is unavailable");
+                return;
+            }
+
+            if (navigator.clipboard[PATCH_KEY]) return;
+
+            const originalWriteText = navigator.clipboard.writeText.bind(navigator.clipboard);
+
+            async function fallbackCopy(text) {
+                const value = String(text);
+                const parent = document.body || document.documentElement;
+                if (!parent) throw new Error("No document body available for clipboard fallback");
+
+                const textarea = document.createElement("textarea");
+                textarea.value = value;
+                textarea.setAttribute("readonly", "");
+                textarea.setAttribute("aria-hidden", "true");
+                textarea.style.position = "fixed";
+                textarea.style.left = "-9999px";
+                textarea.style.top = "0";
+                textarea.style.width = "1px";
+                textarea.style.height = "1px";
+                textarea.style.opacity = "0";
+                textarea.style.pointerEvents = "none";
+
+                parent.appendChild(textarea);
+
+                const previousActiveElement = document.activeElement;
+                textarea.focus();
+                textarea.select();
+                textarea.setSelectionRange(0, value.length);
+
+                const copied = document.execCommand("copy");
+                textarea.remove();
+
+                if (previousActiveElement && typeof previousActiveElement.focus === "function") {
+                    try {
+                        previousActiveElement.focus();
+                    } catch {}
+                }
+
+                if (!copied) throw new Error("document.execCommand('copy') returned false");
+            }
+
+            Object.defineProperty(navigator.clipboard, "writeText", {
+                configurable: true,
+                value: async (text) => {
+                    try {
+                        await fallbackCopy(text);
+                        api.logger.log("copied via fallback", text);
+                    } catch (fallbackError) {
+                        api.logger.warn("fallback failed; trying original writeText", fallbackError);
+                        return originalWriteText(text);
+                    }
+                },
+            });
+
+            Object.defineProperty(navigator.clipboard, PATCH_KEY, {
+                configurable: false,
+                enumerable: false,
+                value: true,
+            });
+
+            api.logger.log("installed");
+        } catch (error) {
+            api.logger.error("install failed", error);
+        }
+    }
+
+    install();
+    window.addEventListener("DOMContentLoaded", install, { once: true });
+};

--- a/docs/plugin-system.md
+++ b/docs/plugin-system.md
@@ -115,6 +115,11 @@ A complete example is available at:
 - `docs/examples/hello-plugin/preload.js`
 - `docs/examples/hello-plugin/renderer.js`
 
+A practical renderer-only workaround plugin is also available at:
+
+- `docs/examples/clipboard-fallback-plugin/manifest.json`
+- `docs/examples/clipboard-fallback-plugin/renderer.js`
+
 To test it:
 
 1. Copy `docs/examples/hello-plugin` into your runtime plugins directory:

--- a/electron-builder.ts
+++ b/electron-builder.ts
@@ -5,6 +5,8 @@ import { applyAppImageSandboxFix } from "./scripts/build/sandboxFix.mjs";
 export const config: Configuration = {
     appId: "app.legcord.Legcord",
     productName: "Legcord",
+    // Biome treats electron-builder macro placeholders as template syntax.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: electron-builder expands these placeholders.
     artifactName: "Legcord-${version}-${os}-${arch}.${ext}",
     beforePack: applyAppImageSandboxFix,
     protocols: [

--- a/src/discord/window.ts
+++ b/src/discord/window.ts
@@ -5,9 +5,11 @@ import {
     app,
     BrowserWindow,
     type BrowserWindowConstructorOptions,
+    clipboard,
     dialog,
     type MessageBoxOptions,
     nativeImage,
+    net,
     screen,
     shell,
 } from "electron";
@@ -75,10 +77,42 @@ function saveWindowState(win: BrowserWindow): void {
     }
 }
 
+async function copyImageFromContext(
+    parameters: { srcURL: string; x: number; y: number },
+    win?: BrowserWindow,
+): Promise<void> {
+    if (parameters.srcURL) {
+        try {
+            const response = await net.fetch(parameters.srcURL);
+            if (!response.ok) throw new Error(`HTTP ${response.status} ${response.statusText}`);
+
+            const image = nativeImage.createFromBuffer(Buffer.from(await response.arrayBuffer()));
+            if (!image.isEmpty()) {
+                clipboard.writeImage(image);
+                return;
+            }
+        } catch (error) {
+            console.warn("[ContextMenu] Failed to copy image from URL, falling back to copyImageAt:", error);
+        }
+    }
+
+    win?.webContents.copyImageAt(parameters.x, parameters.y);
+}
+
 contextMenu({
     showSaveImageAs: true,
+    showCopyImage: false,
     showCopyImageAddress: true,
     showSearchWithGoogle: false,
+    append: (_defaultActions, parameters, win) => [
+        {
+            label: "Copy Image",
+            visible: parameters.mediaType === "image",
+            click: () => {
+                void copyImageFromContext(parameters, win as BrowserWindow | undefined);
+            },
+        },
+    ],
     prepend: (_defaultActions, parameters) => [
         {
             label: getLang("contextMenu-searchGoogle"),
@@ -423,7 +457,7 @@ function doAfterDefiningTheWindow(passedWindow: BrowserWindow): void {
                 lastPolledBounds = { x, y, width, height };
                 saveWindowState(passedWindow);
             }
-        } catch (e) {
+        } catch (_e) {
             // ignore transient errors
         }
     }, 1000);
@@ -520,7 +554,7 @@ export function createWindow() {
         mainWindow.setPosition(storedBounds.x, storedBounds.y);
         mainWindow.setSize(storedBounds.width, storedBounds.height);
     }
-    
+
     mainWindows.push(mainWindow);
     doAfterDefiningTheWindow(mainWindow);
 }


### PR DESCRIPTION
## Summary

Adds a renderer-only example plugin, `clipboard-fallback-plugin`, that patches `navigator.clipboard.writeText` and falls back to `document.execCommand("copy")`.

This is intended as a practical workaround for Discord in-page copy actions failing in Legcord, such as **Copy User ID**, **Copy Message ID**, and **Copy Message Link**.

## Context

This is related to #911. On an affected macOS install, Discord's UI calls `navigator.clipboard.writeText(...)` with the expected value, but the clipboard remains unchanged and the console logs:

```text
Unable to determine render window for element [object HTMLDocument]
```

A fallback based on a temporary textarea + `document.execCommand("copy")` works inside the original click handler.

## Changes

- Adds `docs/examples/clipboard-fallback-plugin/`
  - `manifest.json`
  - `renderer.js`
  - `README.md`
- Links the new practical example from `docs/plugin-system.md`

## Testing

- Manually verified the same fallback strategy in Legcord on macOS using the custom bundle loader.
- After applying the hook, Discord's **Copy User ID** updates the clipboard successfully.
