### PR TITLE
feat: custom invite modal with shelter plugin

### DIFF
--- a/src/@types/legcordWindow.d.ts
+++ b/src/@types/legcordWindow.d.ts
@@ -143,8 +143,13 @@ export interface LegcordRPC {
     }) => void;
 }
 
+export interface LegcordInvite {
+    show: (code: string) => void;
+}
+
 declare global {
     interface Window {
         legcordRPC?: LegcordRPC;
+        legcordInvite?: LegcordInvite;
     }
 }

--- a/src/discord/preload/mods/shelter.mts
+++ b/src/discord/preload/mods/shelter.mts
@@ -8,6 +8,7 @@ const requiredPlugins: Record<string, [string, { isVisible: boolean; allowedActi
     "legcord-power": ["legcord://plugins/power/", { isVisible: false, allowedActions: {} }],
     "legcord-screenshare": ["legcord://plugins/screenshare/", { isVisible: false, allowedActions: {} }],
     "legcord-titlebar": ["legcord://plugins/titlebar/", { isVisible: false, allowedActions: {} }],
+    "legcord-invite": ["legcord://plugins/invite/", { isVisible: false, allowedActions: {} }],
 };
 if (process.platform === "darwin") {
     requiredPlugins["legcord-touchbar"] = [

--- a/src/discord/rpcProcess.ts
+++ b/src/discord/rpcProcess.ts
@@ -3,7 +3,6 @@ import { Worker } from "node:worker_threads";
 import type { GameList } from "arrpc";
 import type { BrowserWindow } from "electron";
 import { getDetectables } from "../common/detectables.js";
-import { navigateTo } from "../common/dom.js";
 
 let rpcWorker: Worker;
 export let processList: GameList[] = [];
@@ -29,7 +28,7 @@ export function startRPC(window: BrowserWindow) {
     rpcWorker.on("message", (message: string) => {
         const json = JSON.parse(message);
         if (json.type === "invite") {
-            navigateTo(window, `/invite/${json.code}`);
+            window.webContents.executeJavaScript(`window.legcordInvite?.show(${JSON.stringify(json.code)})`);
         } else if (json.type === "activity") {
             console.log("activity pulse");
             console.log(json.data);

--- a/src/discord/tray.ts
+++ b/src/discord/tray.ts
@@ -1,7 +1,6 @@
 import { join } from "node:path";
 import { app, Menu, nativeImage, Tray } from "electron";
 import { getConfig } from "../common/config.js";
-import { navigateTo } from "../common/dom.js";
 import { setForceQuit } from "../common/forceQuit.js";
 import { getLang } from "../common/lang.js";
 import { getDisplayVersion } from "../common/version.js";
@@ -60,7 +59,7 @@ export function createTray() {
             label: getLang("tray-supportServer"),
             click() {
                 mainWindows.forEach((mainWindow) => {
-                    navigateTo(mainWindow, "/invite/TnhxcqynZ2");
+                    mainWindow.webContents.executeJavaScript(`window.legcordInvite?.show(${JSON.stringify("TnhxcqynZ2")})`);
                 });
             },
         },

--- a/src/discord/window.ts
+++ b/src/discord/window.ts
@@ -173,7 +173,13 @@ function doAfterDefiningTheWindow(passedWindow: BrowserWindow): void {
                         console.log(commandLine);
                         const lastArg = commandLine.pop();
                         if (lastArg?.startsWith("discord://-")) {
-                            navigateTo(passedWindow, lastArg.replace("discord://-", ""));
+                            const url = lastArg.replace("discord://-", "");
+                            const inviteMatch = url.match(/^\/invite\/([a-zA-Z0-9_-]+)/);
+                            if (inviteMatch) {
+                                passedWindow.webContents.executeJavaScript(`window.legcordInvite?.show(${JSON.stringify(inviteMatch[1])})`);
+                            } else {
+                                navigateTo(passedWindow, url);
+                            }
                         }
                     }
                 } else {
@@ -309,7 +315,13 @@ function doAfterDefiningTheWindow(passedWindow: BrowserWindow): void {
 
     passedWindow.setTouchBar(mainTouchBar);
     app.on("open-url", (_event, url) => {
-        navigateTo(passedWindow, url.replace("discord://-", ""));
+        const resolved = url.replace("discord://-", "");
+        const inviteMatch = resolved.match(/^\/invite\/([a-zA-Z0-9_-]+)/);
+        if (inviteMatch) {
+            passedWindow.webContents.executeJavaScript(`window.legcordInvite?.show(${JSON.stringify(inviteMatch[1])})`);
+        } else {
+            navigateTo(passedWindow, resolved);
+        }
     });
 
     passedWindow.webContents.on("page-title-updated", (e, title) => {

--- a/src/shelter/invite/InviteModal.module.css
+++ b/src/shelter/invite/InviteModal.module.css
@@ -1,0 +1,299 @@
+.inviteContainer {
+    overflow: hidden;
+    border-radius: 0 0 4px 4px;
+}
+
+.banner {
+    position: relative;
+    width: 100%;
+    height: 128px;
+    background: var(--background-tertiary);
+    overflow: hidden;
+}
+
+.bannerImage {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.bannerGradient {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, transparent 60%, var(--background-primary) 100%);
+}
+
+.bannerFallbackBg {
+    width: 100%;
+    height: 100%;
+}
+
+.iconSection {
+    display: flex;
+    justify-content: center;
+    margin-top: -40px;
+    position: relative;
+    z-index: 1;
+}
+
+.serverIcon {
+    width: 80px;
+    height: 80px;
+    border-radius: 20px;
+    border: 6px solid var(--background-primary);
+    background: var(--background-tertiary);
+    object-fit: cover;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.serverIconPlaceholder {
+    width: 80px;
+    height: 80px;
+    border-radius: 20px;
+    border: 6px solid var(--background-primary);
+    background: var(--brand-experiment);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 32px;
+    font-weight: 700;
+    color: var(--white);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.body {
+    padding: 12px 24px 24px;
+    text-align: center;
+}
+
+.serverName {
+    font-size: 22px;
+    font-weight: 700;
+    color: var(--header-primary);
+    margin-bottom: 4px;
+    word-break: break-word;
+    line-height: 1.3;
+}
+
+.serverDescription {
+    font-size: 14px;
+    color: var(--text-muted);
+    margin-bottom: 16px;
+    line-height: 1.4;
+    word-break: break-word;
+}
+
+.stats {
+    display: flex;
+    justify-content: center;
+    gap: 24px;
+    margin-bottom: 20px;
+}
+
+.stat {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 14px;
+    color: var(--text-muted);
+}
+
+.statIcon {
+    width: 16px;
+    height: 16px;
+    color: var(--interactive-normal);
+    flex-shrink: 0;
+}
+
+.statValue {
+    font-weight: 600;
+    color: var(--header-primary);
+}
+
+.actions {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: 100%;
+}
+
+.joinButton {
+    width: 100%;
+    padding: 14px 24px;
+    background: var(--brand-experiment);
+    color: var(--white);
+    border: none;
+    border-radius: 8px;
+    font-size: 15px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s ease;
+    line-height: 1;
+}
+
+.joinButton:hover {
+    background: var(--brand-experiment-hover);
+}
+
+.joinButton:active {
+    background: var(--brand-experiment-active);
+    transform: translateY(1px);
+}
+
+.cancelButton {
+    width: 100%;
+    padding: 14px 24px;
+    background: transparent;
+    color: var(--interactive-normal);
+    border: none;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: color 0.15s ease, background 0.15s ease;
+    line-height: 1;
+}
+
+.cancelButton:hover {
+    color: var(--interactive-hover);
+    background: var(--background-modifier-hover);
+}
+
+.invitedBy {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-bottom: 16px;
+}
+
+.invitedBy a {
+    color: var(--text-link);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.invitedBy a:hover {
+    text-decoration: underline;
+}
+
+.boostInfo {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    color: var(--text-muted);
+    background: var(--background-secondary);
+    padding: 4px 10px;
+    border-radius: 12px;
+    margin-bottom: 16px;
+}
+
+.boostInfo svg {
+    color: var(--guild-boosting-pink);
+}
+
+/* Loading state */
+.loadingContainer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    padding: 80px 24px;
+    color: var(--text-muted);
+    font-size: 14px;
+    min-height: 200px;
+}
+
+.spinner {
+    width: 36px;
+    height: 36px;
+    border: 3px solid var(--background-modifier-accent);
+    border-top-color: var(--interactive-active);
+    border-radius: 50%;
+    animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+.loadingPulse {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+}
+
+.loadingPulse span {
+    width: 6px;
+    height: 6px;
+    background: var(--text-muted);
+    border-radius: 50%;
+    animation: pulse 1.2s ease-in-out infinite;
+}
+
+.loadingPulse span:nth-child(2) {
+    animation-delay: 0.2s;
+}
+
+.loadingPulse span:nth-child(3) {
+    animation-delay: 0.4s;
+}
+
+@keyframes pulse {
+    0%, 80%, 100% { opacity: 0.3; transform: scale(0.8); }
+    40% { opacity: 1; transform: scale(1.2); }
+}
+
+/* Error state */
+.errorContainer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    padding: 60px 24px;
+    min-height: 200px;
+}
+
+.errorIcon {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    background: var(--status-danger-background);
+    color: var(--status-danger);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.errorText {
+    font-size: 15px;
+    color: var(--text-normal);
+    text-align: center;
+    line-height: 1.4;
+}
+
+.errorSubtext {
+    font-size: 13px;
+    color: var(--text-muted);
+    text-align: center;
+}
+
+.retryButton {
+    margin-top: 8px;
+    padding: 10px 24px;
+    background: var(--background-secondary);
+    color: var(--interactive-normal);
+    border: 1px solid var(--background-modifier-accent);
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s ease;
+}
+
+.retryButton:hover {
+    background: var(--background-secondary-alt);
+    color: var(--interactive-hover);
+}

--- a/src/shelter/invite/InviteModal.tsx
+++ b/src/shelter/invite/InviteModal.tsx
@@ -1,0 +1,223 @@
+import { createSignal, onMount } from "solid-js";
+import classes from "./InviteModal.module.css";
+
+const {
+    ui: { ModalRoot, ModalBody, ModalSizes },
+} = shelter;
+
+interface InviteInfo {
+    code: string;
+    guild?: {
+        id: string;
+        name: string;
+        icon: string | null;
+        banner: string | null;
+        description: string | null;
+        features: string[];
+        vanity_url_code: string | null;
+        approximate_member_count: number;
+        approximate_presence_count: number;
+    };
+    channel?: {
+        id: string;
+        name: string;
+        type: number;
+    };
+    inviter?: {
+        id: string;
+        username: string;
+        discriminator: string;
+        avatar: string | null;
+    };
+    expires_at: string | null;
+}
+
+function navigateToInvite(code: string) {
+    const path = `/invite/${encodeURIComponent(code)}`;
+    history.pushState({}, null, path);
+    window.dispatchEvent(new PopStateEvent("popstate", {}));
+}
+
+export const InviteModal = (props: { close: () => void; code: string }) => {
+    const [invite, setInvite] = createSignal<InviteInfo | null>(null);
+    const [loading, setLoading] = createSignal(true);
+    const [error, setError] = createSignal<string | null>(null);
+
+    const fetchInvite = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const res = await fetch(
+                `https://discord.com/api/v10/invites/${encodeURIComponent(props.code)}?with_counts=true&with_expiration=true`,
+                { credentials: "include" },
+            );
+            if (!res.ok) {
+                if (res.status === 404) {
+                    setError("This invite is invalid or has expired.");
+                } else {
+                    setError(`Failed to load invite (${res.status})`);
+                }
+                setLoading(false);
+                return;
+            }
+            const data = (await res.json()) as InviteInfo;
+            setInvite(data);
+            setLoading(false);
+        } catch {
+            setError("Could not connect to Discord.");
+            setLoading(false);
+        }
+    };
+
+    onMount(fetchInvite);
+
+    const handleJoin = () => {
+        navigateToInvite(props.code);
+        props.close();
+    };
+
+    const guildName = () => invite()?.guild?.name ?? invite()?.channel?.name ?? "Unknown Server";
+
+    const guildIcon = () => {
+        const g = invite()?.guild;
+        if (!g?.icon || !g?.id) return null;
+        const ext = g.icon.startsWith("a_") ? "gif" : "png";
+        return `https://cdn.discordapp.com/icons/${g.id}/${g.icon}.${ext}?size=160`;
+    };
+
+    const guildBanner = () => {
+        const g = invite()?.guild;
+        if (!g?.banner || !g?.id) return null;
+        return `https://cdn.discordapp.com/banners/${g.id}/${g.banner}.png?size=480`;
+    };
+
+    const memberCount = () => invite()?.guild?.approximate_member_count;
+    const presenceCount = () => invite()?.guild?.approximate_presence_count;
+
+    const avatarUrl = () => {
+        const inv = invite()?.inviter;
+        if (!inv) return null;
+        if (inv.avatar) {
+            const ext = inv.avatar.startsWith("a_") ? "gif" : "png";
+            return `https://cdn.discordapp.com/avatars/${inv.id}/${inv.avatar}.${ext}?size=40`;
+        }
+        const defaultIndex = Number(inv.discriminator) % 5;
+        return `https://cdn.discordapp.com/embed/avatars/${defaultIndex}.png`;
+    };
+
+    return (
+        <ModalRoot size={ModalSizes.SMALL}>
+            <ModalBody>
+                <div class={classes.inviteContainer}>
+                    {loading() && (
+                        <div class={classes.loadingContainer}>
+                            <div class={classes.spinner} />
+                            <span>Loading invite...</span>
+                            <div class={classes.loadingPulse}>
+                                <span />
+                                <span />
+                                <span />
+                            </div>
+                        </div>
+                    )}
+                    {error() && (
+                        <div class={classes.errorContainer}>
+                            <div class={classes.errorIcon}>
+                                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                    <circle cx="12" cy="12" r="10" />
+                                    <line x1="15" y1="9" x2="9" y2="15" />
+                                    <line x1="9" y1="9" x2="15" y2="15" />
+                                </svg>
+                            </div>
+                            <div class={classes.errorText}>{error()}</div>
+                            <div class={classes.errorSubtext}>This invite link may be broken or expired.</div>
+                            <button type="button" class={classes.retryButton} onClick={fetchInvite}>
+                                Try Again
+                            </button>
+                        </div>
+                    )}
+                    {invite() && !loading() && !error() && (
+                        <>
+                            <div class={classes.banner}>
+                                {guildBanner() ? (
+                                    <img src={guildBanner()!} alt="" class={classes.bannerImage} />
+                                ) : (
+                                    <div
+                                        class={classes.bannerFallbackBg}
+                                        style={{ background: `var(--background-secondary-alt)` }}
+                                    />
+                                )}
+                                <div class={classes.bannerGradient} />
+                            </div>
+                            <div class={classes.iconSection}>
+                                {guildIcon() ? (
+                                    <img src={guildIcon()!} alt="" class={classes.serverIcon} />
+                                ) : (
+                                    <div class={classes.serverIconPlaceholder}>
+                                        {guildName().charAt(0).toUpperCase()}
+                                    </div>
+                                )}
+                            </div>
+                            <div class={classes.body}>
+                                <div class={classes.serverName}>{guildName()}</div>
+                                {invite()?.guild?.description && (
+                                    <div class={classes.serverDescription}>{invite()?.guild?.description}</div>
+                                )}
+                                {invite()?.guild?.features?.includes("BOOSTS_ENABLED") && (
+                                    <div class={classes.boostInfo}>
+                                        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                                            <path d="M11.5 2L3 12h5.5L9 22l9-10h-5.5L11.5 2z" />
+                                        </svg>
+                                        Boost Server
+                                    </div>
+                                )}
+                                {(memberCount() !== undefined || presenceCount() !== undefined) && (
+                                    <div class={classes.stats}>
+                                        {memberCount() !== undefined && (
+                                            <div class={classes.stat}>
+                                                <svg class={classes.statIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                                    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+                                                    <circle cx="9" cy="7" r="4" />
+                                                    <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+                                                    <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+                                                </svg>
+                                                <span class={classes.statValue}>{memberCount()!.toLocaleString()}</span>
+                                                Members
+                                            </div>
+                                        )}
+                                        {presenceCount() !== undefined && (
+                                            <div class={classes.stat}>
+                                                <svg class={classes.statIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                                    <circle cx="12" cy="12" r="10" />
+                                                    <circle cx="12" cy="12" r="3" />
+                                                </svg>
+                                                <span class={classes.statValue}>{presenceCount()!.toLocaleString()}</span>
+                                                Online
+                                            </div>
+                                        )}
+                                    </div>
+                                )}
+                                {invite()?.inviter && (
+                                    <div class={classes.invitedBy}>
+                                        Invited by{" "}
+                                        <span style="font-weight: 500; color: var(--header-primary);">
+                                            {invite()!.inviter!.username}
+                                        </span>
+                                    </div>
+                                )}
+                                <div class={classes.actions}>
+                                    <button type="button" class={classes.joinButton} onClick={handleJoin}>
+                                        Join {guildName()}
+                                    </button>
+                                    <button type="button" class={classes.cancelButton} onClick={props.close}>
+                                        Cancel
+                                    </button>
+                                </div>
+                            </div>
+                        </>
+                    )}
+                </div>
+            </ModalBody>
+        </ModalRoot>
+    );
+};

--- a/src/shelter/invite/index.tsx
+++ b/src/shelter/invite/index.tsx
@@ -1,0 +1,22 @@
+import { InviteModal } from "./InviteModal.jsx";
+
+const {
+    ui: { openModal },
+    util: { log },
+} = shelter;
+
+export function onLoad() {
+    log("Legcord Invite Handler");
+
+    window.legcordInvite = {
+        show: (code: string) => {
+            openModal(({ close }: { close: () => void }) => (
+                <InviteModal close={close} code={code} />
+            ));
+        },
+    };
+}
+
+export function onUnload() {
+    window.legcordInvite = undefined;
+}

--- a/src/shelter/invite/plugin.json
+++ b/src/shelter/invite/plugin.json
@@ -1,0 +1,5 @@
+{
+    "name": "Legcord Invites",
+    "author": "Legcord",
+    "description": "Custom invite handling for Discord invite URLs"
+}


### PR DESCRIPTION
## Summary

Adds a custom invite modal via a shelter plugin, replacing Discord's native invite page redirect.

## Problem

Invite links from RPC, tray, and protocol handlers navigated away from the app to Discord's invite page with no way back.

## Solution

Intercepts invites in `rpcProcess.ts`, `window.ts`, and `tray.ts` and routes them to a new shelter plugin (`legcord-invite`) via `executeJavaScript`. The plugin fetches invite metadata from the Discord API and renders a styled modal with server banner, icon, member stats, and Join/Cancel buttons.

## Risk

Low. All invite flows that previously used `navigateTo` are replaced with `executeJavaScript` calls. The modal is sandboxed within shelter. The banner image had a reactivity bug (`const banner = guildBanner()` evaluated once at mount) which was fixed by calling `guildBanner()` directly in the JSX template.

## Testing

- [x] `pnpm build` — passes (7 plugins, rolldown, all chunks generated)
- [x] `pnpm lint`
- [x] Manual verification: RPC invite, tray support server, protocol handler (`discord://-`), in-app invite link
- [x] Screenshots or recordings for UI changes

## Notes

Fixes https://github.com/Legcord/Legcord/issues/1091 — banner not displaying (fixed Solid.js reactivity issue: `guildBanner()` was called once at mount when `invite()` was still `null`; now called reactively in the template).

## Images 

<img width="1919" height="1030" alt="image" src="https://github.com/user-attachments/assets/5f0133d3-1215-45ed-a1eb-e95badf93656" />

