### PR TITLE
perf: parallelize mod fetching and plugin system initialization

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -218,8 +218,7 @@ if (!app.requestSingleInstanceLock() && getConfig("multiInstance") === false) {
             disableFeatures.add(val);
         });
     }
-    await fetchMods();
-    await initializePluginSystem();
+    await Promise.all([fetchMods(), initializePluginSystem()]);
     void import("./discord/extensions/plugin.js"); // load chrome extensions
     console.log(`[Config Manager] Current config: ${readFileSync(getConfigLocation(), "utf-8")}`);
 


### PR DESCRIPTION
## Summary

Parallelize `fetchMods()` and `initializePluginSystem()` at startup so they run concurrently instead of sequentially, reducing total startup latency.

## Problem

At startup, `fetchMods()` (network-bound — downloads mod bundles from GitHub) and `initializePluginSystem()` (CPU/disk-bound — scans plugin directories, parses manifests) were called one after the other with `await`. Since they share no dependencies, this serialization adds unnecessary wall-clock time (estimated 500ms–2s) to the app launch on every platform.

## Solution

Wrap both calls in `Promise.all([fetchMods(), initializePluginSystem()])` at `src/main.ts:221`. Both tasks now begin immediately, and execution continues as soon as the slower one finishes — effectively cutting the total wait to `max(t1, t2)` instead of `t1 + t2`.

## Risk

Low. The two functions operate on independent subsystems:
- `fetchMods()` lives in `src/discord/extensions/modloader.ts` — it fetches mod repos and writes bundles to disk.
- `initializePluginSystem()` lives in `src/discord/plugins/manager.ts` — it scans `plugins/` directories and loads manifests.
Neither reads the other's output. No shared mutable state. No platform-specific concerns.

## Testing

- [x] `pnpm lint`
- [x] `pnpm build` if this PR touches runtime, bundling, or packaging code
- [x] Manual verification for affected flows — app starts, mods load, plugins initialize correctly

## AI Notice

- [] I have used any AI/LLM tool to generate code or text in this PR. I understand that I am responsible for reviewing and validating any code generated by AI, and that I will be held accountable for any issues caused by this code.
- [X] I have not used any AI to generate code in this PR.

## Notes
