### PR TITLE
fix: add AboutPopup close button

### DIFF
--- a/src/shelter/settings/components/AboutPopup.tsx
+++ b/src/shelter/settings/components/AboutPopup.tsx
@@ -2,7 +2,7 @@ import { createSignal, For, onMount } from "solid-js";
 import classes from "./SupportBanner.module.css";
 
 const {
-    ui: { ModalRoot, ModalBody, ModalHeader, ModalSizes },
+    ui: { ModalRoot, ModalBody, ModalSizes },
 } = shelter;
 
 interface Contributor {
@@ -37,7 +37,32 @@ export const AboutPopup = (props: { close: () => void }) => {
 
     return (
         <ModalRoot size={ModalSizes.MEDIUM} class={classes.modal}>
-            <ModalHeader close={props.close}>About Legcord</ModalHeader>
+            <div className={classes.closeButtonWrapper}>
+                <button
+                    type="button"
+                    className={classes.closeButton}
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        props.close();
+                    }}
+                    aria-label="Close"
+                >
+                    <svg
+                        width="20"
+                        height="20"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        aria-hidden="true"
+                    >
+                        <line x1="18" y1="6" x2="6" y2="18" />
+                        <line x1="6" y1="6" x2="18" y2="18" />
+                    </svg>
+                </button>
+            </div>
             <ModalBody>
                 <div class={classes.aboutContainer}>
                     <div class={classes.aboutHeader}>

--- a/src/shelter/settings/components/SupportBanner.module.css
+++ b/src/shelter/settings/components/SupportBanner.module.css
@@ -454,4 +454,29 @@
 
 .modal {
     max-height: 640px;
+    position: relative;
+}
+
+.closeButton {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    background: var(--background-tertiary);
+    border: 1px solid var(--background-modifier-accent);
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: all 0.2s ease;
+    z-index: 10;
+}
+
+.closeButton:hover {
+    background: var(--background-modifier-hover);
+    color: var(--text-normal);
+    border-color: var(--background-modifier-hover);
 }

--- a/src/shelter/settings/components/SupportBanner.tsx
+++ b/src/shelter/settings/components/SupportBanner.tsx
@@ -10,7 +10,7 @@ const {
 } = shelter;
 
 function openAboutModal() {
-    openModal((close: () => void) => <AboutPopup close={close} />);
+    openModal(({ close }: { close: () => void }) => <AboutPopup close={close} />);
 }
 
 export function SupportBanner() {


### PR DESCRIPTION
## Summary

Replace Shelter's `ModalHeader` in the About popup with a custom close button, and fix the `openModal` call in `SupportBanner` that was passing the wrong value as `close`.

## Problem

Two issues:

1. `SupportBanner.tsx` calls `openModal((close: () => void) => ...)`, but the Shelter `openModal` callback receives an object `{ close, ... }` — not the `close` function directly. This caused `props.close is not a function` when the About popup tried to close.

2. `AboutPopup.tsx` used Shelter's `<ModalHeader close={props.close}>`, which was unreliable and didn't render a visible close button consistently.

## Solution

- **SupportBanner.tsx**: Destructure `{ close }` from the callback argument — `openModal(({ close }: { close: () => void }) => ...)`.
- **AboutPopup.tsx**: Replace `<ModalHeader>` with a hand-rolled close button (absolute-positioned SVG × icon) that calls `props.close()` directly.
- **SupportBanner.module.css**: Add `.closeButton` and `.closeButton:hover` styles (position absolute, hover background/color transitions).

## Risk

Low. The close button uses the same `props.close()` function; only the rendering changes. The `SupportBanner` fix simply corrects how the close function is received.

## Testing

- [x] Manual verification that the About popup opens and closes via the new × button
- [x] Manual verification that clicking outside the modal still closes it (handled by Shelter's ModalRoot)
- [x] `pnpm lint` passes

## AI Notice

- [x] I have used any AI/LLM tool to generate code or text in this PR.

## Notes

The root cause was identified from the console error `legcord-settings:3555 Uncaught TypeError: props.close is not a function` — the stack led to the `$$click` handler on the About popup's close element.

# Screen

<img width="619" height="657" alt="image" src="https://github.com/user-attachments/assets/cc0fdf0e-66ce-4642-b4b9-f1e12bbf98ce" />

