### PR TITLE
fix: macOS traffic light positioning on 'Overlay' window style

### DIFF
--- a/src/discord/window.ts
+++ b/src/discord/window.ts
@@ -541,7 +541,7 @@ export function createWindow() {
             };
             browserWindowOptions.trafficLightPosition = {
                 x: 10,
-                y: 10,
+                y: 8.5,
             };
             break;
     }


### PR DESCRIPTION
## Summary
Adjust the positioning of the macOS traffic light positioning on the 'Overlay' window style, to better align with the window header.

## Problem
The traffic lights are aligned below the header: see the before screenshot below.

## Solution
I adjusted `browserWindowOptions.trafficLightPosition.y` from 10 to 8.5, for the "overlay" case in `src/discord/window.ts`.

## Risk
The macOS traffic light style changed for macOS 26 (Liquid Glass) to a larger style. I'm not sure if this change impacts the placement of the traffic lights on older versions of macOS. Since the last PR I can find on this feature (#860), Discord's design has changed. So, I believe that is the cause of this problem, rather than macOS updates.

## AI Notice

<!-- Please answer truthfully. AI/LLM tools include programs like Claude, Codex, and Cursor -->

- [ ] I have used any AI/LLM tool to generate code or text in this PR. I understand that I am responsible for reviewing and validating any code generated by AI, and that I will be held accountable for any issues caused by this code.
- [x] I have not used any AI to generate code in this PR.

## Notes

### Before
<img width="267" height="111" alt="Screenshot 2026-07-25 at 21 28 20" src="https://github.com/user-attachments/assets/28020629-46c4-4883-a29c-5a26af727f22" />

### After
<img width="267" height="111" alt="Screenshot 2026-07-25 at 21 28 17" src="https://github.com/user-attachments/assets/42066f0d-9ecb-4f50-9920-fd022f243ce1" />



