### PR TITLE
fix: update appimage toolset as per electron-builder docs

### DIFF
--- a/electron-builder.ts
+++ b/electron-builder.ts
@@ -137,6 +137,9 @@ export const config: Configuration = {
         loadBrowserProcessSpecificV8Snapshot: false,
         grantFileProtocolExtraPrivileges: false,
     },
+    toolsets: {
+        appimage: "1.0.3",
+    },
 };
 
 export default config;


### PR DESCRIPTION
## Summary

Add ```ts
    toolsets: {
      appimage: "1.0.3"
    },
    ``` to electron-builder.

## Problem

As per the electron-builder docs (https://www.electron.build/docs/appimage#toolsets), the default setting is deprecated. This setting will be standard in the next version of electron-builder (v27), but might as well do it now.

## Solution

Update toolchain to 1.0.3 as suggested by electron-builder docs. 
"Use toolsets: { appimage: "1.0.3" } for all new projects. The static runtime eliminates the FUSE2 dependency and works on a wider range of Linux distributions. Starting in v27, this will become the default."

## Risk

<!-- Call out anything that could regress, be platform-specific, or require extra review. -->
Flatpak building changes probably but I cannot really test it until 1.3.0 is released.

## Testing

<!-- Describe the checks you ran and any manual smoke tests. -->

- [x] `pnpm lint`
- [x] `pnpm build` if this PR touches runtime, bundling, or packaging code
- [x] Manual verification for affected flows
- [ -] Screenshots or recordings for UI changes

## AI Notice

<!-- Please answer truthfully. AI/LLM tools include programs like Claude, Codex, and Cursor -->

- [ ] I have used any AI/LLM tool to generate code or text in this PR. I understand that I am responsible for reviewing and validating any code generated by AI, and that I will be held accountable for any issues caused by this code.
- [x] I have not used any AI to generate code in this PR.

## Notes

<!-- Add links to related issues, screenshots, follow-up work, or implementation details. -->
