### PR TITLE
fix(ci): switch from install to just run

### DIFF
--- a/.github/workflows/flatpak-node.yml
+++ b/.github/workflows/flatpak-node.yml
@@ -15,11 +15,8 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - name: Install flatpak-node-generator
-              run: pipx install git+https://github.com/flatpak/flatpak-builder-tools.git#subdirectory=node
-
-            - name: Create generated-sources.json
-              run: /root/.local/bin/flatpak-node-generator pnpm pnpm-lock.yaml --node-sdk-extension org.freedesktop.Sdk.Extension.node26 --electron-node-headers
+            - name: Run flatpak-node-generator
+              run: pipx run git+https://github.com/flatpak/flatpak-builder-tools.git#subdirectory=node pnpm pnpm-lock.yaml --node-sdk-extension org.freedesktop.Sdk.Extension.node26 --electron-node-headers
 
             - name: Upload generated-sources.json to release
               run: |


### PR DESCRIPTION
## Summary

switch from pipx install and then running it to just pipx run

## Problem
permission issue

## Solution

<!-- What changed, and why is this the right approach? -->
pipx run

## Risk

<!-- Call out anything that could regress, be platform-specific, or require extra review. -->
still may not work, but it worked locally. 

## Testing

<!-- Describe the checks you ran and any manual smoke tests. -->

- [ ] `pnpm lint`
- [ ] `pnpm build` if this PR touches runtime, bundling, or packaging code
- [x] Manual verification for affected flows
- [ ] Screenshots or recordings for UI changes

## AI Notice

<!-- Please answer truthfully. AI/LLM tools include programs like Claude, Codex, and Cursor -->

- [ ] I have used any AI/LLM tool to generate code or text in this PR. I understand that I am responsible for reviewing and validating any code generated by AI, and that I will be held accountable for any issues caused by this code.
- [ x I have not used any AI to generate code in this PR.

## Notes

<!-- Add links to related issues, screenshots, follow-up work, or implementation details. -->
