### PR TITLE
fix(ci): set pnpm store version

### DIFF
--- a/.github/workflows/flatpak-node.yml
+++ b/.github/workflows/flatpak-node.yml
@@ -16,8 +16,7 @@ jobs:
             - uses: actions/checkout@v4
 
             - name: Run flatpak-node-generator
-              run: pipx run git+https://github.com/flatpak/flatpak-builder-tools.git#subdirectory=node pnpm pnpm-lock.yaml --node-sdk-extension org.freedesktop.Sdk.Extension.node26 --electron-node-headers
-
+              run: pipx run git+https://github.com/flatpak/flatpak-builder-tools.git#subdirectory=node pnpm pnpm-lock.yaml --node-sdk-extension org.freedesktop.Sdk.Extension.node26 --electron-node-headers --pnpm-store-version v11
             - name: Upload generated-sources.json to release
               run: |
                   gh release upload ${{ github.event.release.tag_name }} generated-sources.json


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR changes. -->

## Problem

without the --pnpm-store-version flag, it was being assumed to be v10. pnpm v11 changed it's store.

## Solution

<!-- What changed, and why is this the right approach? -->
added --pnpm-store-version v11
## Risk

<!-- Call out anything that could regress, be platform-specific, or require extra review. -->
n/a
## Testing

<!-- Describe the checks you ran and any manual smoke tests. -->

- [ ] `pnpm lint`
- [ ] `pnpm build` if this PR touches runtime, bundling, or packaging code
- [x] Manual verification for affected flows
- [ ] Screenshots or recordings for UI changes

## AI Notice

<!-- Please answer truthfully. AI/LLM tools include programs like Claude, Codex, and Cursor -->

- [ ] I have used any AI/LLM tool to generate code or text in this PR. I understand that I am responsible for reviewing and validating any code generated by AI, and that I will be held accountable for any issues caused by this code.
- [x] I have not used any AI to generate code in this PR.

## Notes

<!-- Add links to related issues, screenshots, follow-up work, or implementation details. -->
