### PR TITLE
feat: replace observer version patching with CSS pseudo element

### DIFF
--- a/src/discord/preload/patches.mts
+++ b/src/discord/preload/patches.mts
@@ -264,20 +264,22 @@ async function load() {
         addStyle("legcord://assets/css/discord.css");
     });
     injectJS("legcord://assets/js/patchVencordQuickCSS.js");
+
     // Settings info version injection
-    const observer = new MutationObserver(() => {
-        if (document.body.querySelector("#ac-ver")) return;
-
-        const info = document.body.querySelector('[class*="sidebar"] [class*="compactInfo"]');
-        const host = info?.parentElement;
-        if (!host || !/(stable|ptb|canary) \d+|Electron|Chromium/i.test(host.textContent)) return;
-
-        const el = host.querySelector("span")!.cloneNode() as HTMLSpanElement;
-        el.id = "ac-ver";
-        el.textContent = `Legcord Version: ${version}`;
-        info.after(el);
-        observer.disconnect();
-    });
-    observer.observe(document.body, { childList: true, subtree: true });
+    addScript(`(() => {
+        const versionElm = document.createElement("style");
+        versionElm.appendChild(document.createTextNode(\`
+            div[class*="compactInfo"] {
+                margin-bottom: 15px;
+            }
+            div[class*="compactInfo"] > span::before {
+                content: "Legcord Version: ${version}";
+                color: inherit;
+                position: absolute;
+                margin-top: 20px;
+            }
+        \`));
+        document.body.append(versionElm);
+    })()`);
 }
 load();


### PR DESCRIPTION
## Summary

replace mutation observer patching with a css pseudo element

## Problem

the most recent change to the observer added a "observer.disconnect()" after it appends the version element
but discord's settings menu is rebuilt every time you open it so the version only appears the first time you open the menu
then the observer is disconnected so it doesnt append the element again

## Solution

fully replaced the mutation observer with a css pseudo element which makes sure it appears every time

## Risk

the only risk i can think of is the class name changing, but that would also effected the observer implementation

## Testing

- [X] `pnpm lint`
- [ ] `pnpm build` if this PR touches runtime, bundling, or packaging code
- [X] Manual verification for affected flows
- [X] Screenshots or recordings for UI changes

<img width="252" height="157" alt="image" src="https://github.com/user-attachments/assets/66bd4751-3a3f-4a46-aa83-07770932a2ef" />

## AI Notice

- [ ] I have used any AI/LLM tool to generate code or text in this PR. I understand that I am responsible for reviewing and validating any code generated by AI, and that I will be held accountable for any issues caused by this code.
- [X] I have not used any AI to generate code in this PR.
